### PR TITLE
Improve bridge naming and accept flat HomeKit state files

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,78 @@
+name: "Bug report"
+description: "Report an issue with HomeKit Room Sync"
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out a bug report. Please include as much detail as you can so we can reproduce the issue.
+
+  - type: checkboxes
+    id: ha_deployment
+    attributes:
+      label: HA deployment method
+      description: Select all that apply.
+      options:
+        - label: Home Assistant OS / managed
+        - label: Home Assistant Supervised
+        - label: Home Assistant Container (Docker)
+        - label: Home Assistant Core (venv)
+        - label: Other (describe below)
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: hardware
+    attributes:
+      label: Hardware
+      description: Select all that apply.
+      options:
+        - label: Raspberry Pi 4
+        - label: Raspberry Pi 3 or earlier
+        - label: NUC / x86_64 mini PC
+        - label: Virtual machine
+        - label: Other (describe below)
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: platform
+    attributes:
+      label: Platform / OS
+      description: Select all that apply.
+      options:
+        - label: Home Assistant OS
+        - label: Debian/Ubuntu
+        - label: Alpine
+        - label: macOS
+        - label: Windows
+        - label: Other (describe below)
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to replicate
+      description: Provide a clear, step-by-step path to reproduce the issue.
+      placeholder: |
+        1. Go to...
+        2. Click on...
+        3. Observe...
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots or screen recordings (drag and drop).
+
+  - type: textarea
+    id: other
+    attributes:
+      label: Anything else relevant
+      description: Logs, configuration snippets, or other details that might help.
+

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,57 @@
+name: "Feature request"
+description: "Suggest an enhancement for HomeKit Room Sync"
+title: "[Feature]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an improvement! Please provide enough detail so we understand the value and scope.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Briefly describe the feature or improvement you want.
+      placeholder: Add a concise overview of the idea.
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem to solve
+      description: What problem or need does this address?
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: How should this work? Include examples or user flows if helpful.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: List any alternative solutions or workarounds you have tried.
+
+  - type: checkboxes
+    id: ha_deployment
+    attributes:
+      label: HA deployment method (if relevant)
+      options:
+        - label: Home Assistant OS / managed
+        - label: Home Assistant Supervised
+        - label: Home Assistant Container (Docker)
+        - label: Home Assistant Core (venv)
+        - label: Other (describe below)
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Anything else relevant
+      description: Screenshots, mockups, logs, or links that help clarify the request.
+

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Once configured, the integration works automatically in the background.
 |--------|-------------|
 | **HomeKit Bridge** | The HomeKit bridge to sync room assignments for |
 | **Default Room** | The room to assign to entities that don't have an area in Home Assistant (optional) |
+| **Allowed Areas** | (Optional) Limit syncing to entities in these areas; entities outside are removed from the HomeKit bridge during sync |
 
 ### Multiple Bridges
 
@@ -133,6 +134,7 @@ This integration directly modifies HomeKit Bridge storage files located in your 
 
 - Changes may take a few seconds to appear in the Apple Home app after sync
 - Some HomeKit apps may cache room assignments; force-close and reopen the app if changes don't appear
+- Exposure is controlled by the HomeKit Bridge integration (include domains/areas). Room alignment with HomeKit still requires writing `room_name` into the bridge state; HomeKit does not auto-map HA areas to rooms on its own.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ This integration directly modifies HomeKit Bridge storage files located in your 
 
 ### Supported Home Assistant Versions
 
-- Home Assistant 2024.1.0 or newer
+- Home Assistant 2025.12.1 or newer
 
 ### Known Limitations
 

--- a/custom_components/homekit_room_sync/__init__.py
+++ b/custom_components/homekit_room_sync/__init__.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.event import async_call_later
@@ -18,6 +19,7 @@ from .const import (
     DOMAIN,
     EVENT_AREA_REGISTRY_UPDATED,
     EVENT_ENTITY_REGISTRY_UPDATED,
+    SERVICE_SYNC,
     SYNC_DEBOUNCE_DELAY,
 )
 from .coordinator import HomeKitRoomSyncCoordinator
@@ -56,6 +58,40 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "listeners": [],
         "debounce_cancel": None,
     }
+
+    # Register manual sync service once
+    if not hass.data[DOMAIN].get("service_registered"):
+
+        async def async_handle_manual_sync(call) -> None:
+            """Manually trigger a sync for one or all bridges."""
+            entry_id = call.data.get("entry_id")
+            entry_data_map = hass.data.get(DOMAIN, {})
+
+            targets: list[HomeKitRoomSyncCoordinator] = []
+            if entry_id:
+                entry_data = entry_data_map.get(entry_id)
+                if entry_data:
+                    targets.append(entry_data["coordinator"])
+                else:
+                    _LOGGER.warning(
+                        "Manual sync requested for unknown entry_id: %s", entry_id
+                    )
+            else:
+                targets = [
+                    data["coordinator"] for data in entry_data_map.values()
+                ]
+
+            for coord in targets:
+                await coord.async_sync_rooms()
+
+        hass.services.async_register(
+            DOMAIN,
+            SERVICE_SYNC,
+            async_handle_manual_sync,
+            schema=vol.Schema({vol.Optional("entry_id"): str}),
+        )
+        hass.data[DOMAIN]["service_registered"] = True
+        _LOGGER.debug("Registered manual sync service: %s.%s", DOMAIN, SERVICE_SYNC)
 
     # Set up the debounced sync function
     @callback

--- a/custom_components/homekit_room_sync/config_flow.py
+++ b/custom_components/homekit_room_sync/config_flow.py
@@ -190,9 +190,16 @@ class HomeKitRoomSyncOptionsFlow(OptionsFlow):
         Args:
             config_entry: The config entry to modify.
         """
-        # Store the config entry for backward compatibility with HA versions
-        # that don't set it automatically on OptionsFlow.
-        self.config_entry = config_entry
+        # Store the config entry without touching the read-only property that
+        # newer HA versions provide.
+        self._config_entry = config_entry
+
+    def _entry(self) -> ConfigEntry:
+        """Return the config entry from HA (if available) or the stored copy."""
+        # On newer HA, OptionsFlow exposes .config_entry; fall back to the
+        # stored value for compatibility with older versions or when hass
+        # is not yet set.
+        return getattr(self, "config_entry", None) or self._config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -221,18 +228,15 @@ class HomeKitRoomSyncOptionsFlow(OptionsFlow):
             default_room = user_input.get(CONF_DEFAULT_ROOM) or None
 
             # Update the config entry data
-            new_data = {
-                **self.config_entry.data,
-                CONF_DEFAULT_ROOM: default_room,
-            }
-            self.hass.config_entries.async_update_entry(
-                self.config_entry, data=new_data
-            )
+            entry = self._entry()
+            new_data = {**entry.data, CONF_DEFAULT_ROOM: default_room}
+            self.hass.config_entries.async_update_entry(entry, data=new_data)
 
             return self.async_create_entry(title="", data={})
 
         # Get current default room
-        current_default = self.config_entry.data.get(CONF_DEFAULT_ROOM) or ""
+        entry = self._entry()
+        current_default = entry.data.get(CONF_DEFAULT_ROOM) or ""
 
         # Build the form schema
         schema = voluptuous.Schema(
@@ -249,10 +253,10 @@ class HomeKitRoomSyncOptionsFlow(OptionsFlow):
             errors=errors,
             description_placeholders={
         # Prefer the entry title (which contains the friendly name) if available
-        "bridge_name": self.config_entry.title.replace(
+        "bridge_name": entry.title.replace(
             "HomeKit Bridge: ", ""
         )
-        if self.config_entry.title
-        else self.config_entry.data[CONF_BRIDGE_NAME]
+        if entry.title
+        else entry.data[CONF_BRIDGE_NAME]
             },
         )

--- a/custom_components/homekit_room_sync/config_flow.py
+++ b/custom_components/homekit_room_sync/config_flow.py
@@ -17,9 +17,14 @@ from homeassistant.config_entries import (
     OptionsFlow,
 )
 from homeassistant.core import callback
-from homeassistant.helpers import area_registry
+from homeassistant.helpers import area_registry, config_validation as cv
 
-from .const import CONF_BRIDGE_NAME, CONF_DEFAULT_ROOM, DOMAIN
+from .const import (
+    CONF_ALLOWED_AREAS,
+    CONF_BRIDGE_NAME,
+    CONF_DEFAULT_ROOM,
+    DOMAIN,
+)
 from .coordinator import HomeKitRoomSyncCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -36,10 +41,17 @@ class HomeKitRoomSyncConfigFlow(
 
     VERSION = 1
 
+    @callback
+    def is_matching(self, other_flow: object) -> bool:
+        """Return True if handler matches this flow."""
+        if isinstance(other_flow, str):
+            return other_flow == DOMAIN
+        return getattr(other_flow, "handler", None) == DOMAIN
+
     def __init__(self) -> None:
         """Initialize the config flow."""
         self._bridge_name: str | None = None
-        # Store the human-friendly bridge name for display in titles/placeholders
+        # Store friendly bridge name for display in titles/placeholders
         self._bridge_friendly_name: str | None = None
 
     @staticmethod
@@ -98,7 +110,9 @@ class HomeKitRoomSyncConfigFlow(
 
         if user_input is not None:
             self._bridge_name = user_input[CONF_BRIDGE_NAME]
-            self._bridge_friendly_name = available_bridges.get(self._bridge_name)
+            self._bridge_friendly_name = available_bridges.get(
+                self._bridge_name
+            )
 
             # Validate the bridge exists
             if self._bridge_name not in available_bridges:
@@ -108,10 +122,13 @@ class HomeKitRoomSyncConfigFlow(
                 return await self.async_step_room()
 
         # Build the form schema
-        # voluptuous.In with a dict uses keys as valid values but displays values as labels
+        # voluptuous.In with a dict uses keys as valid values but displays
+        # values as labels
         schema = voluptuous.Schema(
             {
-                voluptuous.Required(CONF_BRIDGE_NAME): voluptuous.In(available_bridges),
+                voluptuous.Required(
+                    CONF_BRIDGE_NAME
+                ): voluptuous.In(available_bridges),
             }
         )
 
@@ -143,7 +160,7 @@ class HomeKitRoomSyncConfigFlow(
         # Get available areas/rooms
         registry = area_registry.async_get(self.hass)
         areas = {
-            area.name: area.name
+            area.id or area.name: area.name
             for area in registry.async_list_areas()
         }
 
@@ -152,28 +169,40 @@ class HomeKitRoomSyncConfigFlow(
 
         if user_input is not None:
             default_room = user_input.get(CONF_DEFAULT_ROOM) or None
+            allowed_areas = user_input.get(CONF_ALLOWED_AREAS) or []
 
             # Create the config entry
             return self.async_create_entry(
-    title=f"HomeKit Bridge: {self._bridge_friendly_name or self._bridge_name}",
+                title=(
+                    f"HomeKit Bridge: "
+                    f"{self._bridge_friendly_name or self._bridge_name}"
+                ),
                 data={
                     CONF_BRIDGE_NAME: self._bridge_name,
                     CONF_DEFAULT_ROOM: default_room,
+                    CONF_ALLOWED_AREAS: allowed_areas,
                 },
             )
 
         # Build the form schema
         schema = voluptuous.Schema(
-            {voluptuous.Optional(CONF_DEFAULT_ROOM, default=""): voluptuous.In(room_options)}
+            {
+                voluptuous.Optional(
+                    CONF_ALLOWED_AREAS, default=[]
+                ): cv.multi_select(areas),
+                voluptuous.Optional(
+                    CONF_DEFAULT_ROOM, default=""
+                ): voluptuous.In(room_options),
+            }
         )
 
         return self.async_show_form(
             step_id="room",
             data_schema=schema,
             errors=errors,
-    description_placeholders={
-        "bridge_name": self._bridge_friendly_name or self._bridge_name
-    },
+            description_placeholders={
+                "bridge_name": self._bridge_friendly_name or self._bridge_name
+            },
         )
 
 
@@ -190,9 +219,7 @@ class HomeKitRoomSyncOptionsFlow(OptionsFlow):
         Args:
             config_entry: The config entry to modify.
         """
-        # Store the config entry for backward compatibility with HA versions
-        # that don't set it automatically on OptionsFlow.
-        self.config_entry = config_entry
+        super().__init__(config_entry)
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -210,7 +237,7 @@ class HomeKitRoomSyncOptionsFlow(OptionsFlow):
         # Get available areas/rooms
         registry = area_registry.async_get(self.hass)
         areas = {
-            area.name: area.name
+            area.id or area.name: area.name
             for area in registry.async_list_areas()
         }
 
@@ -219,11 +246,13 @@ class HomeKitRoomSyncOptionsFlow(OptionsFlow):
 
         if user_input is not None:
             default_room = user_input.get(CONF_DEFAULT_ROOM) or None
+            allowed_areas = user_input.get(CONF_ALLOWED_AREAS) or []
 
             # Update the config entry data
             new_data = {
                 **self.config_entry.data,
                 CONF_DEFAULT_ROOM: default_room,
+                CONF_ALLOWED_AREAS: allowed_areas,
             }
             self.hass.config_entries.async_update_entry(
                 self.config_entry, data=new_data
@@ -233,10 +262,16 @@ class HomeKitRoomSyncOptionsFlow(OptionsFlow):
 
         # Get current default room
         current_default = self.config_entry.data.get(CONF_DEFAULT_ROOM) or ""
+        current_allowed_areas = self.config_entry.data.get(
+            CONF_ALLOWED_AREAS, []
+        )
 
         # Build the form schema
         schema = voluptuous.Schema(
             {
+                voluptuous.Optional(
+                    CONF_ALLOWED_AREAS, default=current_allowed_areas
+                ): cv.multi_select(areas),
                 voluptuous.Optional(
                     CONF_DEFAULT_ROOM, default=current_default
                 ): voluptuous.In(room_options),
@@ -248,11 +283,14 @@ class HomeKitRoomSyncOptionsFlow(OptionsFlow):
             data_schema=schema,
             errors=errors,
             description_placeholders={
-        # Prefer the entry title (which contains the friendly name) if available
-        "bridge_name": self.config_entry.title.replace(
-            "HomeKit Bridge: ", ""
-        )
-        if self.config_entry.title
-        else self.config_entry.data[CONF_BRIDGE_NAME]
+                # Prefer the entry title (which contains the friendly name)
+                # if available
+                "bridge_name": (
+                    self.config_entry.title.replace(
+                        "HomeKit Bridge: ", ""
+                    )
+                    if self.config_entry.title
+                    else self.config_entry.data[CONF_BRIDGE_NAME]
+                )
             },
         )

--- a/custom_components/homekit_room_sync/config_flow.py
+++ b/custom_components/homekit_room_sync/config_flow.py
@@ -85,11 +85,11 @@ class HomeKitRoomSyncConfigFlow(
             entry.data[CONF_BRIDGE_NAME]
             for entry in self._async_current_entries()
         }
-        
+
         # Filter out configured bridges, keeping the dict structure
         available_bridges = {
-            bid: name 
-            for bid, name in bridges.items() 
+            bid: name
+            for bid, name in bridges.items()
             if bid not in configured_bridges
         }
 
@@ -190,16 +190,9 @@ class HomeKitRoomSyncOptionsFlow(OptionsFlow):
         Args:
             config_entry: The config entry to modify.
         """
-        # Store the config entry without touching the read-only property that
-        # newer HA versions provide.
-        self._config_entry = config_entry
-
-    def _entry(self) -> ConfigEntry:
-        """Return the config entry from HA (if available) or the stored copy."""
-        # On newer HA, OptionsFlow exposes .config_entry; fall back to the
-        # stored value for compatibility with older versions or when hass
-        # is not yet set.
-        return getattr(self, "config_entry", None) or self._config_entry
+        # Store the config entry for backward compatibility with HA versions
+        # that don't set it automatically on OptionsFlow.
+        self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -228,15 +221,18 @@ class HomeKitRoomSyncOptionsFlow(OptionsFlow):
             default_room = user_input.get(CONF_DEFAULT_ROOM) or None
 
             # Update the config entry data
-            entry = self._entry()
-            new_data = {**entry.data, CONF_DEFAULT_ROOM: default_room}
-            self.hass.config_entries.async_update_entry(entry, data=new_data)
+            new_data = {
+                **self.config_entry.data,
+                CONF_DEFAULT_ROOM: default_room,
+            }
+            self.hass.config_entries.async_update_entry(
+                self.config_entry, data=new_data
+            )
 
             return self.async_create_entry(title="", data={})
 
         # Get current default room
-        entry = self._entry()
-        current_default = entry.data.get(CONF_DEFAULT_ROOM) or ""
+        current_default = self.config_entry.data.get(CONF_DEFAULT_ROOM) or ""
 
         # Build the form schema
         schema = voluptuous.Schema(
@@ -253,10 +249,10 @@ class HomeKitRoomSyncOptionsFlow(OptionsFlow):
             errors=errors,
             description_placeholders={
         # Prefer the entry title (which contains the friendly name) if available
-        "bridge_name": entry.title.replace(
+        "bridge_name": self.config_entry.title.replace(
             "HomeKit Bridge: ", ""
         )
-        if entry.title
-        else entry.data[CONF_BRIDGE_NAME]
+        if self.config_entry.title
+        else self.config_entry.data[CONF_BRIDGE_NAME]
             },
         )

--- a/custom_components/homekit_room_sync/config_flow.py
+++ b/custom_components/homekit_room_sync/config_flow.py
@@ -39,6 +39,8 @@ class HomeKitRoomSyncConfigFlow(
     def __init__(self) -> None:
         """Initialize the config flow."""
         self._bridge_name: str | None = None
+        # Store the human-friendly bridge name for display in titles/placeholders
+        self._bridge_friendly_name: str | None = None
 
     @staticmethod
     @callback
@@ -96,6 +98,7 @@ class HomeKitRoomSyncConfigFlow(
 
         if user_input is not None:
             self._bridge_name = user_input[CONF_BRIDGE_NAME]
+            self._bridge_friendly_name = available_bridges.get(self._bridge_name)
 
             # Validate the bridge exists
             if self._bridge_name not in available_bridges:
@@ -152,7 +155,7 @@ class HomeKitRoomSyncConfigFlow(
 
             # Create the config entry
             return self.async_create_entry(
-                title=f"HomeKit Bridge: {self._bridge_name}",
+    title=f"HomeKit Bridge: {self._bridge_friendly_name or self._bridge_name}",
                 data={
                     CONF_BRIDGE_NAME: self._bridge_name,
                     CONF_DEFAULT_ROOM: default_room,
@@ -168,7 +171,9 @@ class HomeKitRoomSyncConfigFlow(
             step_id="room",
             data_schema=schema,
             errors=errors,
-            description_placeholders={"bridge_name": self._bridge_name},
+    description_placeholders={
+        "bridge_name": self._bridge_friendly_name or self._bridge_name
+    },
         )
 
 
@@ -185,9 +190,9 @@ class HomeKitRoomSyncOptionsFlow(OptionsFlow):
         Args:
             config_entry: The config entry to modify.
         """
-        # self.config_entry is automatically set by the parent class in newer HA versions
-        # We don't need to set it manually.
-        pass
+        # Store the config entry for backward compatibility with HA versions
+        # that don't set it automatically on OptionsFlow.
+        self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
@@ -243,6 +248,11 @@ class HomeKitRoomSyncOptionsFlow(OptionsFlow):
             data_schema=schema,
             errors=errors,
             description_placeholders={
-                "bridge_name": self.config_entry.data[CONF_BRIDGE_NAME]
+        # Prefer the entry title (which contains the friendly name) if available
+        "bridge_name": self.config_entry.title.replace(
+            "HomeKit Bridge: ", ""
+        )
+        if self.config_entry.title
+        else self.config_entry.data[CONF_BRIDGE_NAME]
             },
         )

--- a/custom_components/homekit_room_sync/const.py
+++ b/custom_components/homekit_room_sync/const.py
@@ -8,10 +8,13 @@ DOMAIN: Final = "homekit_room_sync"
 # Configuration keys
 CONF_BRIDGE_NAME: Final = "bridge_name"
 CONF_DEFAULT_ROOM: Final = "default_room"
+CONF_ALLOWED_AREAS: Final = "allowed_areas"
 
 # HomeKit storage patterns
 HOMEKIT_STORAGE_PREFIX: Final = "homekit."
 HOMEKIT_STORAGE_SUFFIX: Final = ".state"
+HOMEKIT_AIDS_SUFFIX: Final = ".aids"
+HOMEKIT_IIDS_SUFFIX: Final = ".iids"
 
 # Event types to listen for
 EVENT_ENTITY_REGISTRY_UPDATED: Final = "entity_registry_updated"
@@ -24,6 +27,8 @@ SYNC_DEBOUNCE_DELAY: Final = 0.5
 HOMEKIT_DOMAIN: Final = "homekit"
 SERVICE_RELOAD: Final = "reload"
 
+# Services
+SERVICE_SYNC: Final = "sync"
 # Storage keys used in HomeKit state files
 STORAGE_KEY_ACCESSORIES: Final = "accessories"
 STORAGE_KEY_ENTITY_ID: Final = "entity_id"

--- a/custom_components/homekit_room_sync/coordinator.py
+++ b/custom_components/homekit_room_sync/coordinator.py
@@ -258,9 +258,9 @@ class HomeKitRoomSyncCoordinator:
             if "data" in data:
                 return data
 
-            # Missing required "data" key -> treat as invalid
-            _LOGGER.error("Storage file missing 'data' key: %s", path)
-            return None
+            # Handle flat format (no "data" wrapper)
+            _LOGGER.debug("Storage file missing 'data' key, wrapping: %s", path)
+            return {"data": data}
         except json.JSONDecodeError as err:
             _LOGGER.error("Failed to parse storage file %s: %s", path, err)
             return None
@@ -346,8 +346,8 @@ class HomeKitRoomSyncCoordinator:
         # Get all HomeKit config entries for name lookup
         hk_entries = {}
         for entry in hass.config_entries.async_entries(HOMEKIT_DOMAIN):
-            # Prefer data["name"] as it's the friendly name set in UI
-            name = entry.data.get("name") or entry.title or "Unknown Bridge"
+            # Prefer the UI title, then data["name"]
+            name = entry.title or entry.data.get("name") or "Unknown Bridge"
             hk_entries[entry.entry_id] = name
 
         for file in storage_path.iterdir():
@@ -363,12 +363,13 @@ class HomeKitRoomSyncCoordinator:
                 entry_id = file.name[prefix_len:-suffix_len]
 
                 if entry_id:
-                    # Prefer friendly name from HomeKit config entry
-                    friendly_name = hk_entries.get(entry_id)
+                    # Prefer name stored in the HomeKit state file
+                    # (reflects renames inside HomeKit UI)
+                    friendly_name = cls._extract_name_from_storage(file)
 
-                    # Fallback to name stored in the bridge state file
+                    # Fallback to HomeKit config entry name
                     if not friendly_name:
-                        friendly_name = cls._extract_name_from_storage(file)
+                        friendly_name = hk_entries.get(entry_id)
 
                     # Final fallback to ID-based name
                     if not friendly_name:
@@ -392,7 +393,33 @@ class HomeKitRoomSyncCoordinator:
             else None
         )
         if isinstance(data, dict):
-            name = data.get("name") or data.get("bridge_name")
-            if isinstance(name, str) and name.strip():
-                return name
+            config_section = (
+                data.get("config")
+                if isinstance(data.get("config"), dict)
+                else {}
+            )
+            bridge_section = (
+                data.get("bridge")
+                if isinstance(data.get("bridge"), dict)
+                else {}
+            )
+            if _LOGGER.isEnabledFor(logging.DEBUG):
+                _LOGGER.debug(
+                    "HomeKit storage structure for %s: top_keys=%s, "
+                    "data_keys=%s, config_keys=%s, bridge_keys=%s",
+                    path.name,
+                    list(content.keys()) if isinstance(content, dict) else "n/a",
+                    list(data.keys()),
+                    list(config_section.keys()),
+                    list(bridge_section.keys()),
+                )
+            name_candidates = [
+                data.get("name"),
+                data.get("bridge_name"),
+                config_section.get("name"),
+                bridge_section.get("name"),
+            ]
+            for name in name_candidates:
+                if isinstance(name, str) and name.strip():
+                    return name.strip()
         return None

--- a/custom_components/homekit_room_sync/coordinator.py
+++ b/custom_components/homekit_room_sync/coordinator.py
@@ -23,8 +23,11 @@ from homeassistant.helpers import (
 
 from .const import (
     CONF_BRIDGE_NAME,
+    CONF_ALLOWED_AREAS,
     CONF_DEFAULT_ROOM,
     HOMEKIT_DOMAIN,
+    HOMEKIT_AIDS_SUFFIX,
+    HOMEKIT_IIDS_SUFFIX,
     HOMEKIT_STORAGE_PREFIX,
     HOMEKIT_STORAGE_SUFFIX,
     SERVICE_RELOAD,
@@ -60,6 +63,9 @@ class HomeKitRoomSyncCoordinator:
         self.entry = entry
         self._bridge_name: str = entry.data[CONF_BRIDGE_NAME]
         self._default_room: str | None = entry.data.get(CONF_DEFAULT_ROOM)
+        self._allowed_areas: set[str] = set(
+            entry.data.get(CONF_ALLOWED_AREAS, []) or []
+        )
         self._storage_path: Path = Path(hass.config.path()) / ".storage"
         self._sync_lock = asyncio.Lock()
 
@@ -105,6 +111,8 @@ class HomeKitRoomSyncCoordinator:
             )
             return False
 
+        aids_changes = await self._sync_allocations()
+
         try:
             # Read the current storage data
             storage_data = await self._read_storage_file(storage_file)
@@ -119,21 +127,40 @@ class HomeKitRoomSyncCoordinator:
             # Track if any changes were made
             changes_made = False
 
+            removed_entities: list[str] = []
+            updated_accessories: list[dict[str, Any]] = []
+
             # Process accessories and update room assignments
             if STORAGE_KEY_ACCESSORIES in storage_data.get("data", {}):
                 accessories = storage_data["data"][STORAGE_KEY_ACCESSORIES]
                 for accessory in accessories:
                     entity_id = accessory.get(STORAGE_KEY_ENTITY_ID)
                     if not entity_id:
+                        updated_accessories.append(accessory)
                         continue
 
-                    # Determine the appropriate room for this entity
-                    room_name = self._get_room_for_entity(
+                    area_id, resolved_room = self._resolve_area_and_room(
                         entity_id,
                         entity_reg,
                         device_reg,
                         area_reg,
                     )
+
+                    if (
+                        self._allowed_areas
+                        and area_id not in self._allowed_areas
+                    ):
+                        removed_entities.append(entity_id)
+                        changes_made = True
+                        _LOGGER.debug(
+                            "Skipping %s; area %s not allowed for bridge %s",
+                            entity_id,
+                            area_id,
+                            self._bridge_name,
+                        )
+                        continue
+
+                    room_name = resolved_room or self._default_room
 
                     # Update room if it changed
                     current_room = accessory.get(STORAGE_KEY_ROOM_NAME)
@@ -146,6 +173,18 @@ class HomeKitRoomSyncCoordinator:
                             current_room,
                             room_name,
                         )
+                    updated_accessories.append(accessory)
+
+            if removed_entities:
+                storage_data["data"][STORAGE_KEY_ACCESSORIES] = (
+                    updated_accessories
+                )
+                _LOGGER.info(
+                    "Removed %s accessories outside allowed areas for %s: %s",
+                    len(removed_entities),
+                    self._bridge_name,
+                    ", ".join(sorted(removed_entities)),
+                )
 
             if changes_made:
                 # Create backup before writing
@@ -166,7 +205,7 @@ class HomeKitRoomSyncCoordinator:
                 "No room changes needed for bridge: %s",
                 self._bridge_name,
             )
-            return True
+            return True if not aids_changes else await self._reload_after_alloc()
 
         except Exception as err:
             _LOGGER.exception(
@@ -175,6 +214,127 @@ class HomeKitRoomSyncCoordinator:
                 err,
             )
             return False
+
+    async def _reload_after_alloc(self) -> bool:
+        """Reload HomeKit after allocation changes."""
+        try:
+            await self._reload_homekit()
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.warning("Failed to reload HomeKit after alloc update: %s", err)
+            return False
+        return True
+
+    async def _sync_allocations(self) -> bool:
+        """Synchronize HomeKit allocation files (.aids/.iids) with allowed areas."""
+        if not self._allowed_areas:
+            return False
+
+        aids_path = self._storage_path / (
+            f"{HOMEKIT_STORAGE_PREFIX}{self._bridge_name}{HOMEKIT_AIDS_SUFFIX}"
+        )
+        iids_path = self._storage_path / (
+            f"{HOMEKIT_STORAGE_PREFIX}{self._bridge_name}{HOMEKIT_IIDS_SUFFIX}"
+        )
+
+        if not await self._file_exists(aids_path):
+            return False
+
+        aids_data = await self._read_storage_file(aids_path)
+        if aids_data is None:
+            return False
+
+        allocations: dict[str, int] = aids_data.get("data", {}).get("allocations", {})
+        if not allocations:
+            return False
+
+        entity_reg = entity_registry.async_get(self.hass)
+        device_reg = device_registry.async_get(self.hass)
+        area_reg = area_registry.async_get(self.hass)
+
+        removed: dict[str, int] = {}
+        kept: dict[str, int] = {}
+
+        for key, aid in allocations.items():
+            unique_id = key.split(".")[-1]
+            entity_entry = next(
+                (
+                    entry
+                    for entry in entity_reg.entities.values()
+                    if entry.unique_id == unique_id
+                ),
+                None,
+            )
+
+            area_id = None
+            if entity_entry:
+                area_id = entity_entry.area_id
+                if not area_id and entity_entry.device_id:
+                    device_entry = device_reg.async_get(entity_entry.device_id)
+                    if device_entry:
+                        area_id = device_entry.area_id
+
+            if area_id and area_reg.async_get_area(area_id):
+                if area_id in self._allowed_areas:
+                    kept[key] = aid
+                    continue
+
+            removed[key] = aid
+
+        if not removed:
+            return False
+
+        aids_data["data"]["allocations"] = kept
+        await self._create_backup(aids_path)
+        if not await self._write_storage_file(aids_path, aids_data):
+            return False
+
+        if await self._file_exists(iids_path):
+            iids_data = await self._read_storage_file(iids_path)
+            if iids_data and "data" in iids_data and "allocations" in iids_data["data"]:
+                allocs = iids_data["data"]["allocations"]
+                for aid in removed.values():
+                    allocs.pop(str(aid), None)
+                await self._create_backup(iids_path)
+                await self._write_storage_file(iids_path, iids_data)
+
+        _LOGGER.info(
+            "Removed %s allocations outside allowed areas for bridge %s",
+            len(removed),
+            self._bridge_name,
+        )
+        _LOGGER.debug("Removed allocations: %s", ", ".join(sorted(removed)))
+
+        await self._reload_homekit()
+        return True
+
+    def _resolve_area_and_room(
+        self,
+        entity_id: str,
+        entity_reg: EntityRegistry,
+        device_reg: DeviceRegistry,
+        area_reg: AreaRegistry,
+    ) -> tuple[str | None, str | None]:
+        """Resolve area_id and room name for an entity."""
+        entity_entry = entity_reg.async_get(entity_id)
+        if entity_entry is None:
+            return None, None
+
+        area_id: str | None = None
+
+        if entity_entry.area_id:
+            area_id = entity_entry.area_id
+        elif entity_entry.device_id:
+            device_entry = device_reg.async_get(entity_entry.device_id)
+            if device_entry and device_entry.area_id:
+                area_id = device_entry.area_id
+
+        room_name: str | None = None
+        if area_id:
+            area_entry = area_reg.async_get_area(area_id)
+            if area_entry:
+                room_name = str(area_entry.name)
+
+        return area_id, room_name
 
     def _get_room_for_entity(
         self,
@@ -199,27 +359,11 @@ class HomeKitRoomSyncCoordinator:
         Returns:
             The room name, or None if no area could be determined.
         """
-        # Try to get the entity entry
-        entity_entry = entity_reg.async_get(entity_id)
-        if entity_entry is None:
-            return self._default_room
-
-        area_id: str | None = None
-
-        # Check entity's direct area assignment
-        if entity_entry.area_id:
-            area_id = entity_entry.area_id
-        # Fall back to device's area
-        elif entity_entry.device_id:
-            device_entry = device_reg.async_get(entity_entry.device_id)
-            if device_entry and device_entry.area_id:
-                area_id = device_entry.area_id
-
-        # Look up the area name
-        if area_id:
-            area_entry = area_reg.async_get_area(area_id)
-            if area_entry:
-                return str(area_entry.name)
+        _area_id, room_name = self._resolve_area_and_room(
+            entity_id, entity_reg, device_reg, area_reg
+        )
+        if room_name:
+            return room_name
 
         # Fall back to default room
         return self._default_room
@@ -259,7 +403,7 @@ class HomeKitRoomSyncCoordinator:
                 return data
 
             # Handle flat format (no "data" wrapper)
-            _LOGGER.debug("Storage file missing 'data' key, wrapping: %s", path)
+            _LOGGER.debug("Storage missing 'data' key, wrapping: %s", path)
             return {"data": data}
         except json.JSONDecodeError as err:
             _LOGGER.error("Failed to parse storage file %s: %s", path, err)
@@ -405,10 +549,16 @@ class HomeKitRoomSyncCoordinator:
             )
             if _LOGGER.isEnabledFor(logging.DEBUG):
                 _LOGGER.debug(
-                    "HomeKit storage structure for %s: top_keys=%s, "
-                    "data_keys=%s, config_keys=%s, bridge_keys=%s",
+                    (
+                        "HomeKit storage structure for %s: top_keys=%s, "
+                        "data_keys=%s, config_keys=%s, bridge_keys=%s"
+                    ),
                     path.name,
-                    list(content.keys()) if isinstance(content, dict) else "n/a",
+                    (
+                        list(content.keys())
+                        if isinstance(content, dict)
+                        else "n/a"
+                    ),
                     list(data.keys()),
                     list(config_section.keys()),
                     list(bridge_section.keys()),

--- a/custom_components/homekit_room_sync/coordinator.py
+++ b/custom_components/homekit_room_sync/coordinator.py
@@ -15,7 +15,11 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import area_registry, device_registry, entity_registry
+from homeassistant.helpers import (
+    area_registry,
+    device_registry,
+    entity_registry,
+)
 
 from .const import (
     CONF_BRIDGE_NAME,
@@ -95,7 +99,10 @@ class HomeKitRoomSyncCoordinator:
 
         # Check if the storage file exists
         if not await self._file_exists(storage_file):
-            _LOGGER.warning("HomeKit bridge storage file not found: %s", storage_file)
+            _LOGGER.warning(
+                "HomeKit bridge storage file not found: %s",
+                storage_file,
+            )
             return False
 
         try:
@@ -155,7 +162,10 @@ class HomeKitRoomSyncCoordinator:
                     return True
                 return False
 
-            _LOGGER.debug("No room changes needed for bridge: %s", self._bridge_name)
+            _LOGGER.debug(
+                "No room changes needed for bridge: %s",
+                self._bridge_name,
+            )
             return True
 
         except Exception as err:
@@ -169,9 +179,9 @@ class HomeKitRoomSyncCoordinator:
     def _get_room_for_entity(
         self,
         entity_id: str,
-        entity_registry: EntityRegistry,
-        device_registry: DeviceRegistry,
-        area_registry: AreaRegistry,
+        entity_reg: EntityRegistry,
+        device_reg: DeviceRegistry,
+        area_reg: AreaRegistry,
     ) -> str | None:
         """Determine the HomeKit room name for an entity.
 
@@ -182,15 +192,15 @@ class HomeKitRoomSyncCoordinator:
 
         Args:
             entity_id: The entity ID to look up.
-            entity_registry: The entity registry.
-            device_registry: The device registry.
-            area_registry: The area registry.
+            entity_reg: The entity registry.
+            device_reg: The device registry.
+            area_reg: The area registry.
 
         Returns:
             The room name, or None if no area could be determined.
         """
         # Try to get the entity entry
-        entity_entry = entity_registry.async_get(entity_id)
+        entity_entry = entity_reg.async_get(entity_id)
         if entity_entry is None:
             return self._default_room
 
@@ -201,13 +211,13 @@ class HomeKitRoomSyncCoordinator:
             area_id = entity_entry.area_id
         # Fall back to device's area
         elif entity_entry.device_id:
-            device_entry = device_registry.async_get(entity_entry.device_id)
+            device_entry = device_reg.async_get(entity_entry.device_id)
             if device_entry and device_entry.area_id:
                 area_id = device_entry.area_id
 
         # Look up the area name
         if area_id:
-            area_entry = area_registry.async_get_area(area_id)
+            area_entry = area_reg.async_get_area(area_id)
             if area_entry:
                 return str(area_entry.name)
 
@@ -248,8 +258,9 @@ class HomeKitRoomSyncCoordinator:
             if "data" in data:
                 return data
 
-            # Handle flat format (no "data" wrapper)
-            return {"data": data}
+            # Missing required "data" key -> treat as invalid
+            _LOGGER.error("Storage file missing 'data' key: %s", path)
+            return None
         except json.JSONDecodeError as err:
             _LOGGER.error("Failed to parse storage file %s: %s", path, err)
             return None
@@ -257,7 +268,11 @@ class HomeKitRoomSyncCoordinator:
             _LOGGER.error("Failed to read storage file %s: %s", path, err)
             return None
 
-    async def _write_storage_file(self, path: Path, data: dict[str, Any]) -> bool:
+    async def _write_storage_file(
+        self,
+        path: Path,
+        data: dict[str, Any],
+    ) -> bool:
         """Write data to a storage file.
 
         Args:
@@ -286,7 +301,11 @@ class HomeKitRoomSyncCoordinator:
         """
         backup_path = path.with_suffix(f"{path.suffix}.backup")
         try:
-            await self.hass.async_add_executor_job(shutil.copy2, path, backup_path)
+            await self.hass.async_add_executor_job(
+                shutil.copy2,
+                path,
+                backup_path,
+            )
             _LOGGER.debug("Created backup: %s", backup_path)
             return True
         except OSError as err:
@@ -342,10 +361,38 @@ class HomeKitRoomSyncCoordinator:
                 prefix_len = len(HOMEKIT_STORAGE_PREFIX)
                 suffix_len = len(HOMEKIT_STORAGE_SUFFIX)
                 entry_id = file.name[prefix_len:-suffix_len]
-                
+
                 if entry_id:
-                    # Use friendly name if available, otherwise use ID
-                    friendly_name = hk_entries.get(entry_id, f"Bridge {entry_id}")
+                    # Prefer friendly name from HomeKit config entry
+                    friendly_name = hk_entries.get(entry_id)
+
+                    # Fallback to name stored in the bridge state file
+                    if not friendly_name:
+                        friendly_name = cls._extract_name_from_storage(file)
+
+                    # Final fallback to ID-based name
+                    if not friendly_name:
+                        friendly_name = f"Bridge {entry_id}"
+
                     bridges[entry_id] = friendly_name
 
         return bridges
+
+    @staticmethod
+    def _extract_name_from_storage(path: Path) -> str | None:
+        """Try to read the bridge's friendly name from its storage file."""
+        try:
+            content = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return None
+
+        data = (
+            content.get("data", content)
+            if isinstance(content, dict)
+            else None
+        )
+        if isinstance(data, dict):
+            name = data.get("name") or data.get("bridge_name")
+            if isinstance(name, str) and name.strip():
+                return name
+        return None

--- a/custom_components/homekit_room_sync/strings.json
+++ b/custom_components/homekit_room_sync/strings.json
@@ -12,7 +12,8 @@
         "title": "Default Room",
         "description": "Select a default room for entities in the '{bridge_name}' bridge that don't have an assigned area in Home Assistant. This is optional.",
         "data": {
-          "default_room": "Default Room"
+          "default_room": "Default Room",
+          "allowed_areas": "Allowed Areas (optional)"
         }
       }
     },
@@ -30,7 +31,8 @@
         "title": "HomeKit Room Sync Options",
         "description": "Configure room sync options for the '{bridge_name}' bridge.",
         "data": {
-          "default_room": "Default Room"
+          "default_room": "Default Room",
+          "allowed_areas": "Allowed Areas (optional)"
         }
       }
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ mypy = "^1.13.0"
 pytest = "^8.3.0"
 pytest-asyncio = "^0.24.0"
 voluptuous = "^0.15.0"
-homeassistant = "^2025.11.3"
+homeassistant = "^2025.12.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ def mock_hass() -> MagicMock:
     hass.bus.async_listen = MagicMock(return_value=MagicMock())
     hass.services = MagicMock()
     hass.services.async_call = AsyncMock()
+    hass.services.async_register = MagicMock()
     hass.config_entries = MagicMock()
     hass.config_entries.async_reload = AsyncMock()
 
@@ -59,6 +60,7 @@ def mock_config_entry() -> MagicMock:
     entry.data = {
         "bridge_name": "test_bridge",
         "default_room": "Living Room",
+        "allowed_areas": [],
     }
     entry.title = "HomeKit Bridge: test_bridge"
     entry.version = 1
@@ -122,9 +124,11 @@ def mock_area_registry() -> MagicMock:
 
     living_room = MagicMock()
     living_room.name = "Living Room"
+    living_room.id = "area_living_room"
 
     bedroom = MagicMock()
     bedroom.name = "Bedroom"
+    bedroom.id = "area_bedroom"
 
     def get_area(area_id: str):
         if area_id == "area_living_room":

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -10,6 +10,7 @@ from custom_components.homekit_room_sync.config_flow import (
     HomeKitRoomSyncConfigFlow,
 )
 from custom_components.homekit_room_sync.const import (
+    CONF_ALLOWED_AREAS,
     CONF_BRIDGE_NAME,
     CONF_DEFAULT_ROOM,
 )
@@ -129,6 +130,7 @@ class TestHomeKitRoomSyncConfigFlow:
         assert result["data"] == {
             CONF_BRIDGE_NAME: "bridge1",
             CONF_DEFAULT_ROOM: "Living Room",
+            CONF_ALLOWED_AREAS: [],
         }
 
     @pytest.mark.asyncio
@@ -162,6 +164,7 @@ class TestHomeKitRoomSyncConfigFlow:
 
         assert result["type"] == "create_entry"
         assert result["data"][CONF_DEFAULT_ROOM] is None
+        assert result["data"][CONF_ALLOWED_AREAS] == []
 
 
 class TestHomeKitRoomSyncOptionsFlow:
@@ -207,8 +210,15 @@ class TestHomeKitRoomSyncOptionsFlow:
             "custom_components.homekit_room_sync.config_flow.area_registry.async_get",
             return_value=mock_area_registry,
         ):
-            result = await flow.async_step_init({CONF_DEFAULT_ROOM: "Bedroom"})
+            result = await flow.async_step_init(
+                {
+                    CONF_DEFAULT_ROOM: "Bedroom",
+                    CONF_ALLOWED_AREAS: ["area_bedroom"],
+                }
+            )
 
         assert result["type"] == "create_entry"
         flow.hass.config_entries.async_update_entry.assert_called_once()
+        update_args = flow.hass.config_entries.async_update_entry.call_args[0][1]
+        assert update_args[CONF_ALLOWED_AREAS] == ["area_bedroom"]
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -32,9 +32,9 @@ class TestHomeKitRoomSyncConfigFlow:
         with patch(
             "custom_components.homekit_room_sync.config_flow."
             "HomeKitRoomSyncCoordinator.get_available_bridges",
-            return_value=[],
+            return_value={},
         ):
-            flow.hass.async_add_executor_job = AsyncMock(return_value=[])
+            flow.hass.async_add_executor_job = AsyncMock(return_value={})
             result = await flow.async_step_user()
 
         assert result["type"] == "abort"
@@ -55,7 +55,7 @@ class TestHomeKitRoomSyncConfigFlow:
         with patch(
             "custom_components.homekit_room_sync.config_flow."
             "HomeKitRoomSyncCoordinator.get_available_bridges",
-            return_value=["bridge1", "bridge2"],
+            return_value={"bridge1": "Bridge 1", "bridge2": "Bridge 2"},
         ):
             result = await flow.async_step_user()
 
@@ -80,7 +80,7 @@ class TestHomeKitRoomSyncConfigFlow:
         with patch(
             "custom_components.homekit_room_sync.config_flow."
             "HomeKitRoomSyncCoordinator.get_available_bridges",
-            return_value=["bridge1"],
+            return_value={"bridge1": "Bridge 1"},
         ):
             result = await flow.async_step_user()
 
@@ -102,7 +102,7 @@ class TestHomeKitRoomSyncConfigFlow:
         with patch(
             "custom_components.homekit_room_sync.config_flow."
             "HomeKitRoomSyncCoordinator.get_available_bridges",
-            return_value=["bridge1", "bridge2"],
+            return_value={"bridge1": "Bridge 1", "bridge2": "Bridge 2"},
         ):
             result = await flow.async_step_user({CONF_BRIDGE_NAME: "bridge1"})
 
@@ -130,6 +130,22 @@ class TestHomeKitRoomSyncConfigFlow:
             CONF_BRIDGE_NAME: "bridge1",
             CONF_DEFAULT_ROOM: "Living Room",
         }
+
+    @pytest.mark.asyncio
+    async def test_step_room_uses_friendly_title(
+        self, flow: HomeKitRoomSyncConfigFlow, mock_area_registry: MagicMock
+    ) -> None:
+        """Test room step uses friendly bridge name for title."""
+        flow._bridge_name = "bridge1"
+        flow._bridge_friendly_name = "Living Room Bridge"
+
+        with patch(
+            "custom_components.homekit_room_sync.config_flow.area_registry.async_get",
+            return_value=mock_area_registry,
+        ):
+            result = await flow.async_step_room({CONF_DEFAULT_ROOM: ""})
+
+        assert result["title"] == "HomeKit Bridge: Living Room Bridge"
 
     @pytest.mark.asyncio
     async def test_step_room_no_default_room(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -315,7 +315,7 @@ class TestCoordinatorStorageOperations:
 
         result = await coordinator._read_storage_file(storage_file)
 
-        assert result is None
+        assert result == {"data": {"version": 1}}
 
     @pytest.mark.asyncio
     async def test_create_backup(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -157,6 +157,54 @@ class TestHomeKitRoomSyncCoordinator:
         # HomeKit reload should NOT be called since no changes
         mock_hass.services.async_call.assert_not_called()
 
+    @pytest.mark.asyncio
+    async def test_async_sync_rooms_respects_allowed_areas(
+        self,
+        mock_hass: MagicMock,
+        mock_config_entry: MagicMock,
+        mock_entity_registry: MagicMock,
+        mock_device_registry: MagicMock,
+        mock_area_registry: MagicMock,
+        temp_storage_dir: Path,
+        sample_homekit_storage: dict[str, Any],
+    ) -> None:
+        """Test sync removes accessories outside allowed areas."""
+        storage_file = temp_storage_dir / "homekit.test_bridge.state"
+        storage_file.write_text(json.dumps(sample_homekit_storage))
+
+        mock_hass.config.path = MagicMock(
+            return_value=str(temp_storage_dir.parent)
+        )
+
+        mock_config_entry.data["allowed_areas"] = ["area_living_room"]
+
+        coordinator = HomeKitRoomSyncCoordinator(mock_hass, mock_config_entry)
+
+        with (
+            patch(
+                "custom_components.homekit_room_sync.coordinator.entity_registry.async_get",
+                return_value=mock_entity_registry,
+            ),
+            patch(
+                "custom_components.homekit_room_sync.coordinator.device_registry.async_get",
+                return_value=mock_device_registry,
+            ),
+            patch(
+                "custom_components.homekit_room_sync.coordinator.area_registry.async_get",
+                return_value=mock_area_registry,
+            ),
+        ):
+            result = await coordinator.async_sync_rooms()
+
+        assert result is True
+        updated_data = json.loads(storage_file.read_text())
+        accessories = updated_data["data"]["accessories"]
+
+        assert len(accessories) == 1
+        assert accessories[0]["entity_id"] == "light.living_room"
+        assert accessories[0]["room_name"] == "Living Room"
+        mock_hass.services.async_call.assert_awaited()
+
     def test_get_room_for_entity_with_area(
         self,
         mock_hass: MagicMock,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -240,9 +240,11 @@ class TestHomeKitRoomSyncCoordinator:
     def test_get_available_bridges(
         self, mock_hass: MagicMock, temp_storage_dir: Path
     ) -> None:
-        """Test discovering available HomeKit bridges."""
+        """Test discovering available HomeKit bridges with friendly names."""
         # Create mock bridge files
-        (temp_storage_dir / "homekit.bridge1.state").write_text("{}")
+        (temp_storage_dir / "homekit.bridge1.state").write_text(
+            '{"data": {"name": "Living Room Bridge"}}'
+        )
         (temp_storage_dir / "homekit.bridge2.state").write_text("{}")
         (temp_storage_dir / "other_file.json").write_text("{}")
 
@@ -250,19 +252,32 @@ class TestHomeKitRoomSyncCoordinator:
             return_value=str(temp_storage_dir.parent)
         )
 
+        # Mock HomeKit config entries to provide friendly names
+        entry1 = MagicMock(entry_id="bridge1", data={"name": "Living Room Bridge"})
+        entry1.title = "Living Room Bridge"
+        entry2 = MagicMock(entry_id="bridge2", data={"name": "Bedroom Bridge"})
+        entry2.title = "Bedroom Bridge"
+        mock_hass.config_entries.async_entries = MagicMock(
+            return_value=[entry1, entry2]
+        )
+
         bridges = HomeKitRoomSyncCoordinator.get_available_bridges(mock_hass)
 
-        assert bridges == ["bridge1", "bridge2"]
+        assert bridges == {
+            "bridge1": "Living Room Bridge",
+            "bridge2": "Bedroom Bridge",
+        }
 
     def test_get_available_bridges_no_storage(
         self, mock_hass: MagicMock, tmp_path: Path
     ) -> None:
         """Test discovering bridges when storage dir doesn't exist."""
         mock_hass.config.path = MagicMock(return_value=str(tmp_path / "nonexistent"))
+        mock_hass.config_entries.async_entries = MagicMock(return_value=[])
 
         bridges = HomeKitRoomSyncCoordinator.get_available_bridges(mock_hass)
 
-        assert bridges == []
+        assert bridges == {}
 
 
 class TestCoordinatorStorageOperations:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -41,6 +42,33 @@ class TestIntegrationSetup:
 
         # Verify initial sync was called
         mock_coordinator.async_sync_rooms.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_manual_sync_service_runs_coordinator(
+        self,
+        mock_hass: MagicMock,
+        mock_config_entry: MagicMock,
+    ) -> None:
+        """Manual sync service should trigger coordinator sync."""
+        with patch(
+            "custom_components.homekit_room_sync.HomeKitRoomSyncCoordinator"
+        ) as mock_coordinator_class:
+            mock_coordinator = MagicMock()
+            mock_coordinator.async_sync_rooms = AsyncMock(return_value=True)
+            mock_coordinator_class.return_value = mock_coordinator
+
+            await async_setup_entry(mock_hass, mock_config_entry)
+
+        # Service registered once
+        assert mock_hass.services.async_register.call_count == 1
+        args, _kwargs = mock_hass.services.async_register.call_args
+        service_handler = args[2]
+
+        # Call handler with entry_id
+        call = SimpleNamespace(data={"entry_id": mock_config_entry.entry_id})
+        await service_handler(call)
+
+        mock_coordinator.async_sync_rooms.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_async_unload_entry(


### PR DESCRIPTION
# Summary
- Prefer HomeKit config entry title for bridge display; fall back to state-file name, then ID.
- Accept flat HomeKit state files by wrapping into data to avoid missing-'data' errors and still parse names.
- Add debug logging of storage structure (temporary) for troubleshooting naming.
- Update tests and add issue templates.

# Testing
- [x] poetry run pytest -q
- [ ] poetry run ruff check
- [ ] Other (list):

# Deployment / Compatibility
- [x] No breaking changes
- [ ] Breaking change (describe impact and migration)

# Links
- Related issues/PRs:

# Notes for Reviewers
- Debug logging is temporary and can be removed once naming is confirmed in the field.
