### PR TITLE
Enhance homekit area filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,6 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Contributors Welcome](https://img.shields.io/badge/Contributors-Welcome-brightgreen.svg)](https://github.com/lcrostarosa/homekit-room-sync/blob/master/CONTRIBUTING.md)
 
-> [!CAUTION]
-> **DISCLAIMER: This integration directly modifies internal Home Assistant storage files. YOU MUST BACK UP YOUR HOME ASSISTANT CONFIGURATION BEFORE INSTALLING OR USING THIS INTEGRATION. The authors are not responsible for any data loss or corruption.**
-
 A Home Assistant custom integration that automatically synchronizes your Home Assistant Areas with HomeKit Room assignments.
 
 ## Why This Exists
@@ -77,35 +74,22 @@ If you have multiple HomeKit bridges, you can add the integration multiple times
 
 ## How It Works
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                    Home Assistant                               │
-│                                                                 │
-│  ┌──────────────┐    ┌─────────────────────────┐                │
-│  │ Entity/Area  │───▶│ HomeKit Room Sync       │                │
-│  │ Registry     │    │ (Listens for changes)   │                │
-│  └──────────────┘    └───────────┬─────────────┘                │
-│                                  │                              │
-│                                  ▼                              │
-│                      ┌─────────────────────────┐                │
-│                      │ .storage/homekit.*.state│                │
-│                      │ (Updates room_name)     │                │
-│                      └───────────┬─────────────┘                │
-│                                  │                              │
-│                                  ▼                              │
-│                      ┌─────────────────────────┐                │
-│                      │ homekit.reload service  │                │
-│                      │ (Applies changes)       │                │
-│                      └───────────┬─────────────┘                │
-│                                  │                              │
-└──────────────────────────────────┼──────────────────────────────┘
-                                   │
-                                   ▼
-                        ┌─────────────────────┐
-                        │   Apple HomeKit     │
-                        │   (Updated rooms)   │
-                        └─────────────────────┘
-```
+1. **Listen for registry changes** – the integration subscribes to entity, device and area registry signals so it knows when an entity moves rooms, areas are renamed, or new hardware appears.
+2. **Compute an exposure plan** – for each managed HomeKit bridge we calculate the entities that belong to the selected Areas, then merge any manual include/exclude overrides.
+3. **Update the official HomeKit config entry** – we write the computed lists to the bridge’s `filter` (`include_entities`, `exclude_entities`, `include_areas`) and update `entity_config` so every exposed entity gets a HomeKit `room` matching its Home Assistant Area (or the configured default).
+4. **Reload the HomeKit bridge** – after updating the config entry we call `async_reload` on the HomeKit integration so it re-reads the filter and reconfigures the bridge.
+
+Because the integration now uses Home Assistant’s public config entry APIs, there are no brittle edits to `.storage/homekit.*` files.
+
+During every configuration change (initial setup or options flow) and every automatic sync you’ll see a log entry that previews which entities will be exposed so you can verify the filters before they reach Apple Home.
+
+### Exposure Rules
+
+- **Area filter** – when you select Areas, only entities that resolve to those Area IDs (either directly or via their device) are exposed.
+- **Include overrides** – always expose these entity IDs even if they are outside the Area filter.
+- **Exclude overrides** – remove these entity IDs even if they belong to an allowed Area.
+- **Room naming** – the HomeKit `room` value matches the Area name. If an entity does not have an Area but you provide a default room, that label is used instead.
+- **Automatic resync** – any registry change (entity added/removed, Area rename, moving a device between Areas) triggers a debounced recomputation followed by a HomeKit bridge reload.
 
 ### Room Assignment Priority
 
@@ -118,13 +102,9 @@ For each entity, the room is determined in the following order:
 
 ## Important Notes
 
-⚠️ **Storage Modification Warning**
-
-This integration directly modifies HomeKit Bridge storage files located in your Home Assistant `.storage` directory. While the integration creates backups before making changes, you should:
-
-- Keep regular backups of your Home Assistant configuration
-- Understand that incorrect modifications could affect your HomeKit setup
-- Check the Home Assistant logs if you encounter issues
+- The integration updates the official HomeKit config entry using Home Assistant’s public APIs—no `.storage` files are touched.
+- Every sync logs the list of exposed entities so you can confirm the filters that will reach Apple Home.
+- If you change Areas or move devices frequently, expect the bridge to reload automatically; this is intentional so HomeKit always reflects the latest assignments.
 
 ### Supported Home Assistant Versions
 

--- a/custom_components/homekit_room_sync/__init__.py
+++ b/custom_components/homekit_room_sync/__init__.py
@@ -7,6 +7,7 @@ HomeKit Bridge integration.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING
 
@@ -15,14 +16,18 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.event import async_call_later
 
+from .bridge_manager import HomeKitBridgeManager, parse_managed_bridge_configs
 from .const import (
+    ATTR_BRIDGE_ID,
+    ATTR_ENTRY_ID,
+    CONF_MANAGED_BRIDGES,
     DOMAIN,
     EVENT_AREA_REGISTRY_UPDATED,
+    EVENT_DEVICE_REGISTRY_UPDATED,
     EVENT_ENTITY_REGISTRY_UPDATED,
     SERVICE_SYNC,
     SYNC_DEBOUNCE_DELAY,
 )
-from .coordinator import HomeKitRoomSyncCoordinator
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -48,13 +53,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """
     _LOGGER.debug("Setting up HomeKit Room Sync for bridge: %s", entry.title)
 
-    # Initialize the coordinator
-    coordinator = HomeKitRoomSyncCoordinator(hass, entry)
+    bridge_configs = parse_managed_bridge_configs(entry)
+    if not bridge_configs:
+        _LOGGER.error(
+            "No HomeKit bridges configured for %s. Please re-run the config flow.",
+            entry.title or entry.entry_id,
+        )
+        return False
+
+    manager = HomeKitBridgeManager(hass, entry, bridge_configs)
 
     # Store coordinator and listener references for cleanup
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {
-        "coordinator": coordinator,
+        "manager": manager,
         "listeners": [],
         "debounce_cancel": None,
     }
@@ -64,31 +76,46 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         async def async_handle_manual_sync(call) -> None:
             """Manually trigger a sync for one or all bridges."""
-            entry_id = call.data.get("entry_id")
-            entry_data_map = hass.data.get(DOMAIN, {})
+            entry_id = call.data.get(ATTR_ENTRY_ID)
+            bridge_id = call.data.get(ATTR_BRIDGE_ID)
 
-            targets: list[HomeKitRoomSyncCoordinator] = []
+            async def _sync_target(manager: HomeKitBridgeManager) -> None:
+                if bridge_id:
+                    if bridge_id in manager.bridge_ids:
+                        await manager.async_sync(bridge_id)
+                    return
+                await manager.async_sync()
+
+            domain_data = hass.data.get(DOMAIN, {})
             if entry_id:
-                entry_data = entry_data_map.get(entry_id)
-                if entry_data:
-                    targets.append(entry_data["coordinator"])
-                else:
+                entry_data = domain_data.get(entry_id)
+                if not entry_data:
                     _LOGGER.warning(
-                        "Manual sync requested for unknown entry_id: %s", entry_id
+                        "Manual sync requested for unknown entry_id: %s",
+                        entry_id,
                     )
-            else:
-                targets = [
-                    data["coordinator"] for data in entry_data_map.values()
-                ]
+                    return
+                await _sync_target(entry_data["manager"])
+                return
 
-            for coord in targets:
-                await coord.async_sync_rooms()
+            tasks = [
+                _sync_target(entry_data["manager"])
+                for key, entry_data in domain_data.items()
+                if key != "service_registered"
+            ]
+            if tasks:
+                await asyncio.gather(*tasks)
 
         hass.services.async_register(
             DOMAIN,
             SERVICE_SYNC,
             async_handle_manual_sync,
-            schema=vol.Schema({vol.Optional("entry_id"): str}),
+            schema=vol.Schema(
+                {
+                    vol.Optional(ATTR_ENTRY_ID): str,
+                    vol.Optional(ATTR_BRIDGE_ID): str,
+                }
+            ),
         )
         hass.data[DOMAIN]["service_registered"] = True
         _LOGGER.debug("Registered manual sync service: %s.%s", DOMAIN, SERVICE_SYNC)
@@ -121,7 +148,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 return
 
             entry_data["debounce_cancel"] = None
-            await coordinator.async_sync_rooms()
+            await manager.async_sync()
 
         # Schedule new sync with debounce delay
         entry_data["debounce_cancel"] = async_call_later(
@@ -141,6 +168,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     listeners.append(hass.bus.async_listen(EVENT_AREA_REGISTRY_UPDATED, schedule_sync))
     _LOGGER.debug("Registered listener for %s", EVENT_AREA_REGISTRY_UPDATED)
 
+    listeners.append(
+        hass.bus.async_listen(EVENT_DEVICE_REGISTRY_UPDATED, schedule_sync)
+    )
+    _LOGGER.debug("Registered listener for %s", EVENT_DEVICE_REGISTRY_UPDATED)
+
     # Store listeners for cleanup
     entry_data = hass.data[DOMAIN][entry.entry_id]
     entry_data["listeners"] = listeners  # type: ignore[assignment]
@@ -150,7 +182,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     # Perform initial sync
     _LOGGER.info("Performing initial room sync for bridge: %s", entry.title)
-    await coordinator.async_sync_rooms()
+    await manager.async_sync()
 
     return True
 
@@ -196,11 +228,13 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     for unsub in entry_data.get("listeners", []):
         unsub()
 
-    _LOGGER.info("Successfully unloaded HomeKit Room Sync for bridge: %s", entry.title)
+    await entry_data["manager"].async_shutdown()
+
+    _LOGGER.info("Successfully unloaded HomeKit Room Sync for entry: %s", entry.title)
     return True
 
 
-async def async_migrate_entry(_hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate old entry to new version.
 
     This function handles config entry version migrations for
@@ -215,8 +249,23 @@ async def async_migrate_entry(_hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """
     _LOGGER.debug("Migrating from version %s", entry.version)
 
-    # Currently at version 1, no migration needed
     if entry.version == 1:
+        bridge_configs = parse_managed_bridge_configs(entry)
+        if not bridge_configs:
+            _LOGGER.error("Unable to migrate config entry %s: no bridges", entry.entry_id)
+            return False
+
+        entry.version = 2
+        data = {**entry.data}
+        data.pop("bridge_name", None)
+        data.pop("allowed_areas", None)
+        data.pop("default_room", None)
+        data[CONF_MANAGED_BRIDGES] = [cfg.serialize() for cfg in bridge_configs]
+        hass.config_entries.async_update_entry(entry, data=data)
+        _LOGGER.info("Migrated HomeKit Room Sync entry %s to version 2", entry.entry_id)
+        return True
+
+    if entry.version == 2:
         return True
 
     _LOGGER.error("Migration from version %s is not supported", entry.version)

--- a/custom_components/homekit_room_sync/bridge_manager.py
+++ b/custom_components/homekit_room_sync/bridge_manager.py
@@ -21,7 +21,6 @@ from .const import (
     CONF_MANAGED_BRIDGES,
 )
 from .coordinator import HomeKitRoomSyncCoordinator
-from .storage import HomeKitStorageClient
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -125,13 +124,11 @@ class HomeKitBridgeManager:
         """Initialize the manager."""
         self._hass = hass
         self._entry = entry
-        self._storage = HomeKitStorageClient(hass)
         self._coordinators: dict[str, HomeKitRoomSyncCoordinator] = {
             cfg.bridge_id: HomeKitRoomSyncCoordinator(
                 hass,
                 entry,
                 cfg,
-                self._storage,
             )
             for cfg in bridge_configs
         }

--- a/custom_components/homekit_room_sync/bridge_manager.py
+++ b/custom_components/homekit_room_sync/bridge_manager.py
@@ -1,0 +1,192 @@
+"""Bridge management helpers for HomeKit Room Sync."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Iterable
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    CONF_ALLOWED_AREAS,
+    CONF_BRIDGE_ID,
+    CONF_BRIDGE_NAME,
+    CONF_BRIDGE_TITLE,
+    CONF_DEFAULT_ROOM,
+    CONF_EXCLUDE_ENTITIES,
+    CONF_INCLUDE_ENTITIES,
+    CONF_MANAGED_BRIDGES,
+)
+from .coordinator import HomeKitRoomSyncCoordinator
+from .storage import HomeKitStorageClient
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True)
+class ManagedBridgeConfig:
+    """In-memory representation of a HomeKit bridge configuration."""
+
+    bridge_id: str
+    friendly_name: str
+    allowed_areas: set[str]
+    include_entities: set[str]
+    exclude_entities: set[str]
+    default_room: str | None
+
+    @property
+    def title(self) -> str:
+        """Return the human-friendly title."""
+        return self.friendly_name or self.bridge_id
+
+    def serialize(self) -> dict[str, object]:
+        """Convert to dict suitable for ConfigEntry data."""
+        return {
+            CONF_BRIDGE_ID: self.bridge_id,
+            CONF_BRIDGE_TITLE: self.friendly_name,
+            CONF_ALLOWED_AREAS: sorted(self.allowed_areas),
+            CONF_INCLUDE_ENTITIES: sorted(self.include_entities),
+            CONF_EXCLUDE_ENTITIES: sorted(self.exclude_entities),
+            CONF_DEFAULT_ROOM: self.default_room,
+        }
+
+    @classmethod
+    def from_dict(cls, raw: dict[str, object]) -> ManagedBridgeConfig:
+        """Create a config from stored data."""
+        return cls(
+            bridge_id=str(
+                raw.get(CONF_BRIDGE_ID) or raw.get(CONF_BRIDGE_NAME) or ""
+            ),
+            friendly_name=str(raw.get(CONF_BRIDGE_TITLE) or raw.get(CONF_BRIDGE_NAME) or ""),
+            allowed_areas=set(_coerce_str_list(raw.get(CONF_ALLOWED_AREAS))),
+            include_entities=set(_coerce_str_list(raw.get(CONF_INCLUDE_ENTITIES))),
+            exclude_entities=set(_coerce_str_list(raw.get(CONF_EXCLUDE_ENTITIES))),
+            default_room=_coerce_optional_str(raw.get(CONF_DEFAULT_ROOM)),
+        )
+
+
+def _coerce_str_list(value: object) -> list[str]:
+    if isinstance(value, list):
+        return [str(item) for item in value if isinstance(item, str)]
+    if isinstance(value, tuple):
+        return [str(item) for item in value if isinstance(item, str)]
+    return []
+
+
+def _coerce_optional_str(value: object) -> str | None:
+    if isinstance(value, str):
+        value = value.strip()
+        return value or None
+    return None
+
+
+def parse_managed_bridge_configs(entry: ConfigEntry) -> list[ManagedBridgeConfig]:
+    """Parse managed bridge configurations from a config entry."""
+    configs: list[ManagedBridgeConfig] = []
+
+    stored = entry.data.get(CONF_MANAGED_BRIDGES)
+    if isinstance(stored, Iterable):
+        for raw in stored:
+            if isinstance(raw, dict):
+                cfg = ManagedBridgeConfig.from_dict(raw)
+                if cfg.bridge_id:
+                    configs.append(cfg)
+        return configs
+
+    # Legacy single-bridge entries (version 1)
+    legacy_bridge_id = entry.data.get(CONF_BRIDGE_NAME)
+    if isinstance(legacy_bridge_id, str) and legacy_bridge_id:
+        configs.append(
+            ManagedBridgeConfig(
+                bridge_id=legacy_bridge_id,
+                friendly_name=entry.title or legacy_bridge_id,
+                allowed_areas=set(_coerce_str_list(entry.data.get(CONF_ALLOWED_AREAS))),
+                include_entities=set(),
+                exclude_entities=set(),
+                default_room=_coerce_optional_str(entry.data.get(CONF_DEFAULT_ROOM)),
+            )
+        )
+
+    return configs
+
+
+class HomeKitBridgeManager:
+    """Manage multiple HomeKit Room Sync coordinators."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        bridge_configs: list[ManagedBridgeConfig],
+    ) -> None:
+        """Initialize the manager."""
+        self._hass = hass
+        self._entry = entry
+        self._storage = HomeKitStorageClient(hass)
+        self._coordinators: dict[str, HomeKitRoomSyncCoordinator] = {
+            cfg.bridge_id: HomeKitRoomSyncCoordinator(
+                hass,
+                entry,
+                cfg,
+                self._storage,
+            )
+            for cfg in bridge_configs
+        }
+
+    @property
+    def bridge_ids(self) -> list[str]:
+        """Return the managed bridge IDs."""
+        return list(self._coordinators.keys())
+
+    def get_friendly_name(self, bridge_id: str) -> str:
+        """Return the friendly name for a bridge ID."""
+        coordinator = self._coordinators.get(bridge_id)
+        if coordinator is None:
+            return bridge_id
+        return coordinator.config.title
+
+    async def async_sync(self, bridge_id: str | None = None) -> bool:
+        """Trigger synchronization."""
+        if bridge_id:
+            coordinator = self._coordinators.get(bridge_id)
+            if not coordinator:
+                _LOGGER.warning(
+                    "Requested sync for unknown HomeKit bridge %s",
+                    bridge_id,
+                )
+                return False
+            return await coordinator.async_sync_rooms()
+
+        if not self._coordinators:
+            _LOGGER.debug("No HomeKit bridges configured for entry %s", self._entry.title)
+            return True
+
+        results = await asyncio.gather(
+            *(coord.async_sync_rooms() for coord in self._coordinators.values()),
+            return_exceptions=True,
+        )
+
+        success = True
+        for bridge_id, result in zip(self._coordinators, results, strict=False):
+            if isinstance(result, Exception):
+                success = False
+                _LOGGER.error(
+                    "Sync failed for HomeKit bridge %s: %s",
+                    bridge_id,
+                    result,
+                )
+            elif result is False:
+                success = False
+        return success
+
+    async def async_shutdown(self) -> None:
+        """Cleanup resources when entry unloads."""
+        self._coordinators.clear()
+
+    @property
+    def coordinators(self) -> dict[str, HomeKitRoomSyncCoordinator]:
+        """Expose coordinators for testing."""
+        return self._coordinators

--- a/custom_components/homekit_room_sync/config_flow.py
+++ b/custom_components/homekit_room_sync/config_flow.py
@@ -1,15 +1,11 @@
-"""Config flow for HomeKit Room Sync integration.
-
-This module provides the configuration UI for setting up and
-managing HomeKit Room Sync bridge configurations.
-"""
+"""Config flow for HomeKit Room Sync integration."""
 
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Iterable
 
-import voluptuous
+import voluptuous as vol
 from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
@@ -21,276 +17,405 @@ from homeassistant.helpers import area_registry, config_validation as cv
 
 from .const import (
     CONF_ALLOWED_AREAS,
+    CONF_BRIDGE_ID,
     CONF_BRIDGE_NAME,
+    CONF_BRIDGE_TITLE,
     CONF_DEFAULT_ROOM,
+    CONF_EXCLUDE_ENTITIES,
+    CONF_INCLUDE_ENTITIES,
+    CONF_MANAGED_BRIDGES,
     DOMAIN,
 )
-from .coordinator import HomeKitRoomSyncCoordinator
+from .storage import async_discover_bridges
 
 _LOGGER = logging.getLogger(__name__)
 
 
-class HomeKitRoomSyncConfigFlow(
-    ConfigFlow, domain=DOMAIN
-):  # type: ignore[call-arg]
-    """Handle a config flow for HomeKit Room Sync.
+def _parse_entity_text(value: Any) -> list[str]:
+    """Normalize user-entered entity lists."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        source = ",".join(str(item) for item in value)
+    else:
+        source = str(value)
+    parts = {part.strip() for part in source.replace("\n", ",").split(",")}
+    return sorted(part for part in parts if part)
 
-    This config flow guides the user through selecting a HomeKit bridge
-    and optionally setting a default room for entities without areas.
-    """
 
-    VERSION = 1
+def _list_to_text(values: Iterable[str]) -> str:
+    entries = sorted({val for val in values if val})
+    return "\n".join(entries)
 
-    @callback
-    def is_matching(self, other_flow: object) -> bool:
-        """Return True if handler matches this flow."""
-        if isinstance(other_flow, str):
-            return other_flow == DOMAIN
-        return getattr(other_flow, "handler", None) == DOMAIN
+
+class BridgeFlowMixin:
+    """Shared helpers for config and options flows."""
 
     def __init__(self) -> None:
-        """Initialize the config flow."""
-        self._bridge_name: str | None = None
-        # Store friendly bridge name for display in titles/placeholders
-        self._bridge_friendly_name: str | None = None
+        self._area_options: dict[str, str] | None = None
+        self._area_name_lookup: dict[str, str] = {}
+        self._area_id_lookup: dict[str, str] = {}
+        self._discovered_bridges: dict[str, str] = {}
+        self._selected_bridge_ids: list[str] = []
+        self._bridge_form_index = 0
+        self._bridge_payloads: list[dict[str, Any]] = []
+        self._existing_bridge_map: dict[str, dict[str, Any]] = {}
+
+    async def _ensure_area_data(self) -> None:
+        if self._area_options is not None:
+            return
+
+        registry = area_registry.async_get(self.hass)
+        options: dict[str, str] = {}
+        name_lookup: dict[str, str] = {}
+        id_lookup: dict[str, str] = {}
+
+        for area in sorted(
+            registry.async_list_areas(),
+            key=lambda area: (area.name or "").lower(),
+        ):
+            key = area.id or area.name
+            if not key:
+                continue
+            label = area.name or key
+            options[key] = label
+            name_lookup[key] = label
+            id_lookup[key] = area.id or key
+
+        self._area_options = options
+        self._area_name_lookup = name_lookup
+        self._area_id_lookup = id_lookup
+
+    def _area_key_for_id(self, area_id: str) -> str | None:
+        for key, stored_id in self._area_id_lookup.items():
+            if stored_id == area_id:
+                return key
+        return None
+
+    def _build_bridge_schema(self, defaults: dict[str, Any]) -> vol.Schema:
+        area_options = dict(self._area_options or {})
+
+        allowed_defaults: list[str] = []
+        for area_id in defaults.get(CONF_ALLOWED_AREAS, []):
+            key = self._area_key_for_id(area_id)
+            if key is None:
+                area_options[area_id] = area_id
+                self._area_id_lookup[area_id] = area_id
+                key = area_id
+            allowed_defaults.append(key)
+
+        room_options = {"": "(No default room)"}
+        room_options.update(area_options)
+
+        default_room_name = defaults.get(CONF_DEFAULT_ROOM)
+        default_room_key = ""
+        if default_room_name:
+            for key, name in self._area_name_lookup.items():
+                if name == default_room_name:
+                    default_room_key = key
+                    break
+            else:
+                room_options[default_room_name] = default_room_name
+                self._area_name_lookup[default_room_name] = default_room_name
+                default_room_key = default_room_name
+
+        include_defaults = _list_to_text(defaults.get(CONF_INCLUDE_ENTITIES, []))
+        exclude_defaults = _list_to_text(defaults.get(CONF_EXCLUDE_ENTITIES, []))
+
+        return vol.Schema(
+            {
+                vol.Optional(
+                    CONF_ALLOWED_AREAS,
+                    default=allowed_defaults,
+                ): cv.multi_select(area_options),
+                vol.Optional(
+                    CONF_DEFAULT_ROOM,
+                    default=default_room_key,
+                ): vol.In(room_options),
+                vol.Optional(
+                    CONF_INCLUDE_ENTITIES,
+                    default=include_defaults,
+                ): str,
+                vol.Optional(
+                    CONF_EXCLUDE_ENTITIES,
+                    default=exclude_defaults,
+                ): str,
+            }
+        )
+
+    def _serialize_bridge_input(
+        self,
+        bridge_id: str,
+        friendly_name: str,
+        user_input: dict[str, Any],
+    ) -> dict[str, Any]:
+        allowed_keys = user_input.get(CONF_ALLOWED_AREAS) or []
+        allowed_ids = sorted(
+            {
+                self._area_id_lookup.get(key, key)
+                for key in allowed_keys
+                if key
+            }
+        )
+
+        default_room_key = user_input.get(CONF_DEFAULT_ROOM) or ""
+        default_room = (
+            self._area_name_lookup.get(default_room_key)
+            if default_room_key
+            else None
+        )
+        if default_room is None and default_room_key:
+            default_room = default_room_key
+
+        include_entities = _parse_entity_text(user_input.get(CONF_INCLUDE_ENTITIES))
+        include_set = set(include_entities)
+        exclude_entities = [
+            entity
+            for entity in _parse_entity_text(user_input.get(CONF_EXCLUDE_ENTITIES))
+            if entity not in include_set
+        ]
+
+        return {
+            CONF_BRIDGE_ID: bridge_id,
+            CONF_BRIDGE_TITLE: friendly_name,
+            CONF_ALLOWED_AREAS: allowed_ids,
+            CONF_DEFAULT_ROOM: default_room,
+            CONF_INCLUDE_ENTITIES: include_entities,
+            CONF_EXCLUDE_ENTITIES: exclude_entities,
+        }
+
+    async def _async_handle_bridge_step(
+        self,
+        step_id: str,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        if not self._selected_bridge_ids:
+            return await self._finish_bridge_flow()
+
+        await self._ensure_area_data()
+
+        bridge_id = self._selected_bridge_ids[self._bridge_form_index]
+        friendly_name = self._discovered_bridges.get(bridge_id, bridge_id)
+        defaults = self._existing_bridge_map.get(bridge_id, {})
+
+        if user_input is not None:
+            payload = self._serialize_bridge_input(bridge_id, friendly_name, user_input)
+            self._bridge_payloads.append(payload)
+            self._bridge_form_index += 1
+
+            if self._bridge_form_index >= len(self._selected_bridge_ids):
+                return await self._finish_bridge_flow()
+
+            return await self._async_handle_bridge_step(step_id)
+
+        schema = self._build_bridge_schema(defaults)
+        return self.async_show_form(
+            step_id=step_id,
+            data_schema=schema,
+            description_placeholders={
+                "bridge_name": friendly_name,
+                "current_index": str(self._bridge_form_index + 1),
+                "bridge_total": str(len(self._selected_bridge_ids)),
+            },
+        )
+
+    async def _finish_bridge_flow(self) -> ConfigFlowResult:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+
+class HomeKitRoomSyncConfigFlow(
+    BridgeFlowMixin, ConfigFlow, domain=DOMAIN
+):  # type: ignore[call-arg]
+    """Handle a config flow for HomeKit Room Sync."""
+
+    VERSION = 2
+
+    def __init__(self) -> None:
+        ConfigFlow.__init__(self)
+        BridgeFlowMixin.__init__(self)
 
     @staticmethod
     @callback
     def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
-        """Get the options flow handler.
-
-        Args:
-            config_entry: The config entry to get options for.
-
-        Returns:
-            The options flow handler.
-        """
         return HomeKitRoomSyncOptionsFlow(config_entry)
 
     async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
+        self,
+        user_input: dict[str, Any] | None = None,
     ) -> ConfigFlowResult:
-        """Handle the initial step - select a HomeKit bridge.
-
-        This step presents the user with a list of available HomeKit
-        bridges discovered from the storage directory.
-
-        Args:
-            user_input: User-provided form data.
-
-        Returns:
-            The next step or an error if validation fails.
-        """
         errors: dict[str, str] = {}
 
-        # Get available bridges
-        # Returns dict[bridge_id, friendly_name]
-        bridges = await self.hass.async_add_executor_job(
-            HomeKitRoomSyncCoordinator.get_available_bridges, self.hass
-        )
-
-        if not bridges:
+        discovered = await async_discover_bridges(self.hass)
+        if not discovered:
             return self.async_abort(reason="no_bridges")
 
-        # Check for already configured bridges
-        configured_bridges = {
-            entry.data[CONF_BRIDGE_NAME]
+        configured = {
+            managed.get(CONF_BRIDGE_ID)
             for entry in self._async_current_entries()
+            for managed in entry.data.get(CONF_MANAGED_BRIDGES, [])
+            if isinstance(managed, dict)
+        }
+        for entry in self._async_current_entries():
+            legacy_bridge = entry.data.get(CONF_BRIDGE_NAME)
+            if isinstance(legacy_bridge, str):
+                configured.add(legacy_bridge)
+
+        available = {
+            bridge_id: name
+            for bridge_id, name in discovered.items()
+            if bridge_id not in configured
         }
 
-        # Filter out configured bridges, keeping the dict structure
-        available_bridges = {
-            bid: name
-            for bid, name in bridges.items()
-            if bid not in configured_bridges
-        }
-
-        if not available_bridges:
+        if not available:
             return self.async_abort(reason="all_bridges_configured")
 
         if user_input is not None:
-            self._bridge_name = user_input[CONF_BRIDGE_NAME]
-            self._bridge_friendly_name = available_bridges.get(
-                self._bridge_name
-            )
-
-            # Validate the bridge exists
-            if self._bridge_name not in available_bridges:
-                errors[CONF_BRIDGE_NAME] = "invalid_bridge"
+            selected = user_input.get(CONF_MANAGED_BRIDGES, [])
+            if not selected:
+                errors["base"] = "select_bridge"
             else:
-                # Move to room selection step
-                return await self.async_step_room()
+                self._discovered_bridges = available
+                self._selected_bridge_ids = selected
+                self._bridge_payloads = []
+                self._bridge_form_index = 0
+                self._existing_bridge_map = {}
+                return await self.async_step_bridge()
 
-        # Build the form schema
-        # voluptuous.In with a dict uses keys as valid values but displays
-        # values as labels
-        schema = voluptuous.Schema(
+        schema = vol.Schema(
             {
-                voluptuous.Required(
-                    CONF_BRIDGE_NAME
-                ): voluptuous.In(available_bridges),
+                vol.Required(CONF_MANAGED_BRIDGES): cv.multi_select(available),
             }
         )
-
         return self.async_show_form(
             step_id="user",
             data_schema=schema,
             errors=errors,
             description_placeholders={
-                "bridge_count": str(len(available_bridges))
+                "bridge_count": str(len(available)),
             },
         )
 
-    async def async_step_room(
-        self, user_input: dict[str, Any] | None = None
+    async def async_step_bridge(
+        self,
+        user_input: dict[str, Any] | None = None,
     ) -> ConfigFlowResult:
-        """Handle the room selection step.
+        return await self._async_handle_bridge_step("bridge", user_input)
 
-        This step allows the user to select a default room for entities
-        that don't have an assigned area in Home Assistant.
+    async def _finish_bridge_flow(self) -> ConfigFlowResult:
+        if not self._bridge_payloads:
+            return self.async_abort(reason="no_bridges")
 
-        Args:
-            user_input: User-provided form data.
+        if len(self._bridge_payloads) == 1:
+            title = f"HomeKit Bridge: {self._bridge_payloads[0][CONF_BRIDGE_TITLE]}"
+        else:
+            title = f"HomeKit Room Sync ({len(self._bridge_payloads)} bridges)"
 
-        Returns:
-            The created config entry or an error.
-        """
-        errors: dict[str, str] = {}
-
-        # Get available areas/rooms
-        registry = area_registry.async_get(self.hass)
-        areas = {
-            area.id or area.name: area.name
-            for area in registry.async_list_areas()
-        }
-
-        # Add "None" option for no default room
-        room_options = {"": "(No default room)"} | areas
-
-        if user_input is not None:
-            default_room = user_input.get(CONF_DEFAULT_ROOM) or None
-            allowed_areas = user_input.get(CONF_ALLOWED_AREAS) or []
-
-            # Create the config entry
-            return self.async_create_entry(
-                title=(
-                    f"HomeKit Bridge: "
-                    f"{self._bridge_friendly_name or self._bridge_name}"
-                ),
-                data={
-                    CONF_BRIDGE_NAME: self._bridge_name,
-                    CONF_DEFAULT_ROOM: default_room,
-                    CONF_ALLOWED_AREAS: allowed_areas,
-                },
-            )
-
-        # Build the form schema
-        schema = voluptuous.Schema(
-            {
-                voluptuous.Optional(
-                    CONF_ALLOWED_AREAS, default=[]
-                ): cv.multi_select(areas),
-                voluptuous.Optional(
-                    CONF_DEFAULT_ROOM, default=""
-                ): voluptuous.In(room_options),
-            }
-        )
-
-        return self.async_show_form(
-            step_id="room",
-            data_schema=schema,
-            errors=errors,
-            description_placeholders={
-                "bridge_name": self._bridge_friendly_name or self._bridge_name
-            },
+        return self.async_create_entry(
+            title=title,
+            data={CONF_MANAGED_BRIDGES: self._bridge_payloads},
         )
 
 
-class HomeKitRoomSyncOptionsFlow(OptionsFlow):
-    """Handle options flow for HomeKit Room Sync.
-
-    This options flow allows users to modify the default room
-    assignment after initial configuration.
-    """
+class HomeKitRoomSyncOptionsFlow(BridgeFlowMixin, OptionsFlow):
+    """Handle options flow for HomeKit Room Sync."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize the options flow.
-
-        Args:
-            config_entry: The config entry to modify.
-        """
-        super().__init__(config_entry)
+        self.config_entry = config_entry
+        OptionsFlow.__init__(self, config_entry)
+        BridgeFlowMixin.__init__(self)
 
     async def async_step_init(
-        self, user_input: dict[str, Any] | None = None
+        self,
+        user_input: dict[str, Any] | None = None,
     ) -> ConfigFlowResult:
-        """Handle the options form.
-
-        Args:
-            user_input: User-provided form data.
-
-        Returns:
-            The updated options or form to display.
-        """
         errors: dict[str, str] = {}
 
-        # Get available areas/rooms
-        registry = area_registry.async_get(self.hass)
-        areas = {
-            area.id or area.name: area.name
-            for area in registry.async_list_areas()
+        discovered = await async_discover_bridges(self.hass)
+        current_configs = [
+            managed
+            for managed in self.config_entry.data.get(CONF_MANAGED_BRIDGES, [])
+            if isinstance(managed, dict)
+        ]
+        current_ids = [
+            managed.get(CONF_BRIDGE_ID)
+            for managed in current_configs
+            if isinstance(managed.get(CONF_BRIDGE_ID), str)
+        ]
+
+        other_entries = [
+            entry
+            for entry in self.hass.config_entries.async_entries(DOMAIN)
+            if entry.entry_id != self.config_entry.entry_id
+        ]
+        reserved_ids = {
+            managed.get(CONF_BRIDGE_ID)
+            for entry in other_entries
+            for managed in entry.data.get(CONF_MANAGED_BRIDGES, [])
+            if isinstance(managed, dict)
         }
 
-        # Add "None" option for no default room
-        room_options = {"": "(No default room)"} | areas
+        available = {
+            bridge_id: name
+            for bridge_id, name in discovered.items()
+            if bridge_id not in reserved_ids or bridge_id in current_ids
+        }
+
+        # Ensure currently configured bridges remain selectable even if missing
+        for bridge_id in current_ids:
+            if bridge_id and bridge_id not in available:
+                available[bridge_id] = next(
+                    (
+                        cfg.get(CONF_BRIDGE_TITLE)
+                        for cfg in current_configs
+                        if cfg.get(CONF_BRIDGE_ID) == bridge_id
+                    ),
+                    bridge_id,
+                )
 
         if user_input is not None:
-            default_room = user_input.get(CONF_DEFAULT_ROOM) or None
-            allowed_areas = user_input.get(CONF_ALLOWED_AREAS) or []
+            selected = user_input.get(CONF_MANAGED_BRIDGES, [])
+            if not selected:
+                errors["base"] = "select_bridge"
+            else:
+                self._discovered_bridges = available
+                self._selected_bridge_ids = selected
+                self._bridge_payloads = []
+                self._bridge_form_index = 0
+                self._existing_bridge_map = {
+                    cfg.get(CONF_BRIDGE_ID): cfg for cfg in current_configs
+                }
+                return await self.async_step_bridge()
 
-            # Update the config entry data
-            new_data = {
-                **self.config_entry.data,
-                CONF_DEFAULT_ROOM: default_room,
-                CONF_ALLOWED_AREAS: allowed_areas,
-            }
-            self.hass.config_entries.async_update_entry(
-                self.config_entry, data=new_data
-            )
-
-            return self.async_create_entry(title="", data={})
-
-        # Get current default room
-        current_default = self.config_entry.data.get(CONF_DEFAULT_ROOM) or ""
-        current_allowed_areas = self.config_entry.data.get(
-            CONF_ALLOWED_AREAS, []
-        )
-
-        # Build the form schema
-        schema = voluptuous.Schema(
+        schema = vol.Schema(
             {
-                voluptuous.Optional(
-                    CONF_ALLOWED_AREAS, default=current_allowed_areas
-                ): cv.multi_select(areas),
-                voluptuous.Optional(
-                    CONF_DEFAULT_ROOM, default=current_default
-                ): voluptuous.In(room_options),
+                vol.Required(
+                    CONF_MANAGED_BRIDGES,
+                    default=current_ids,
+                ): cv.multi_select(available),
             }
         )
-
         return self.async_show_form(
             step_id="init",
             data_schema=schema,
             errors=errors,
             description_placeholders={
-                # Prefer the entry title (which contains the friendly name)
-                # if available
-                "bridge_name": (
-                    self.config_entry.title.replace(
-                        "HomeKit Bridge: ", ""
-                    )
-                    if self.config_entry.title
-                    else self.config_entry.data[CONF_BRIDGE_NAME]
-                )
+                "bridge_count": str(len(available)),
             },
         )
+
+    async def async_step_bridge(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        return await self._async_handle_bridge_step("bridge", user_input)
+
+    async def _finish_bridge_flow(self) -> ConfigFlowResult:
+        new_data = {
+            **self.config_entry.data,
+            CONF_MANAGED_BRIDGES: self._bridge_payloads,
+        }
+        self.hass.config_entries.async_update_entry(
+            self.config_entry,
+            data=new_data,
+        )
+        return self.async_create_entry(title="", data={})

--- a/custom_components/homekit_room_sync/config_flow.py
+++ b/custom_components/homekit_room_sync/config_flow.py
@@ -386,8 +386,20 @@ class HomeKitRoomSyncOptionsFlow(BridgeFlowMixin, OptionsFlow):
     """Handle options flow for HomeKit Room Sync."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:
-        OptionsFlow.__init__(self, config_entry)
+        self._safe_options_init(config_entry)
         BridgeFlowMixin.__init__(self)
+
+    def _safe_options_init(self, config_entry: ConfigEntry) -> None:
+        """Initialize OptionsFlow while remaining compatible with test mocks."""
+        try:
+            OptionsFlow.__init__(self, config_entry)  # type: ignore[misc]
+        except TypeError:
+            # Some mock environments (and older HA versions) provide an OptionsFlow
+            # base without an __init__ implementation. Fall back to storing the
+            # config entry manually so tests keep working.
+            self.config_entry = config_entry
+            if not hasattr(self, "hass"):
+                self.hass = getattr(config_entry, "hass", None)
 
     def _show_menu(self, **kwargs: Any) -> ConfigFlowResult:
         """Show a menu, using HA's helper when available."""

--- a/custom_components/homekit_room_sync/config_flow.py
+++ b/custom_components/homekit_room_sync/config_flow.py
@@ -161,13 +161,18 @@ class BridgeFlowMixin:
         )
 
         default_room_key = user_input.get(CONF_DEFAULT_ROOM) or ""
-        default_room = (
-            self._area_name_lookup.get(default_room_key)
-            if default_room_key
-            else None
-        )
-        if default_room is None and default_room_key:
-            default_room = default_room_key
+        default_room = None
+        if default_room_key:
+            default_room = self._area_name_lookup.get(default_room_key)
+            if default_room is None:
+                area_id = self._area_id_lookup.get(default_room_key)
+                if area_id:
+                    registry = area_registry.async_get(self.hass)
+                    area_entry = registry.async_get_area(area_id)
+                    if area_entry and area_entry.name:
+                        default_room = str(area_entry.name)
+            if default_room is None:
+                default_room = default_room_key
 
         include_entities = _parse_entity_text(user_input.get(CONF_INCLUDE_ENTITIES))
         include_set = set(include_entities)

--- a/custom_components/homekit_room_sync/config_flow.py
+++ b/custom_components/homekit_room_sync/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.config_entries import (
 from homeassistant.core import callback
 from homeassistant.helpers import area_registry, config_validation as cv
 
+from .bridge_manager import ManagedBridgeConfig
 from .const import (
     CONF_ALLOWED_AREAS,
     CONF_BRIDGE_ID,
@@ -26,6 +27,7 @@ from .const import (
     CONF_MANAGED_BRIDGES,
     DOMAIN,
 )
+from .exposure import build_exposure_plan
 from .storage import async_discover_bridges
 
 _LOGGER = logging.getLogger(__name__)
@@ -222,6 +224,27 @@ class BridgeFlowMixin:
     async def _finish_bridge_flow(self) -> ConfigFlowResult:  # pragma: no cover - overridden
         raise NotImplementedError
 
+    def _log_exposure_preview(self, payloads: list[dict[str, Any]]) -> None:
+        """Log which entities will be exposed for each configured bridge."""
+        for payload in payloads:
+            config = ManagedBridgeConfig.from_dict(payload)
+            plan = build_exposure_plan(self.hass, config)
+            if plan.include_entities:
+                sample = ", ".join(plan.include_entities[:10])
+                if len(plan.include_entities) > 10:
+                    sample = f"{sample}, …"
+                _LOGGER.info(
+                    "Preview: bridge %s will expose %d entities (%s)",
+                    config.title,
+                    len(plan.include_entities),
+                    sample,
+                )
+            else:
+                _LOGGER.info(
+                    "Preview: bridge %s currently exposes no entities",
+                    config.title,
+                )
+
 
 class HomeKitRoomSyncConfigFlow(
     BridgeFlowMixin, ConfigFlow, domain=DOMAIN
@@ -310,6 +333,7 @@ class HomeKitRoomSyncConfigFlow(
         else:
             title = f"HomeKit Room Sync ({len(self._bridge_payloads)} bridges)"
 
+        self._log_exposure_preview(self._bridge_payloads)
         return self.async_create_entry(
             title=title,
             data={CONF_MANAGED_BRIDGES: self._bridge_payloads},
@@ -320,7 +344,7 @@ class HomeKitRoomSyncOptionsFlow(BridgeFlowMixin, OptionsFlow):
     """Handle options flow for HomeKit Room Sync."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:
-        self._config_entry = config_entry
+        OptionsFlow.__init__(self, config_entry)
         BridgeFlowMixin.__init__(self)
 
     async def async_step_init(
@@ -413,6 +437,7 @@ class HomeKitRoomSyncOptionsFlow(BridgeFlowMixin, OptionsFlow):
             **self.config_entry.data,
             CONF_MANAGED_BRIDGES: self._bridge_payloads,
         }
+        self._log_exposure_preview(self._bridge_payloads)
         self.hass.config_entries.async_update_entry(
             self.config_entry,
             data=new_data,

--- a/custom_components/homekit_room_sync/config_flow.py
+++ b/custom_components/homekit_room_sync/config_flow.py
@@ -15,8 +15,20 @@ from homeassistant.config_entries import (
 from homeassistant.core import callback
 from homeassistant.helpers import area_registry, config_validation as cv
 
-from .bridge_manager import ManagedBridgeConfig
+try:  # Home Assistant runtime
+    from homeassistant.data_entry_flow import FlowResultType
+except Exception:  # Tests with mocks
+    from enum import Enum
+
+    class FlowResultType(Enum):
+        """Fallback FlowResultType for tests."""
+
+        FORM = "form"
+        MENU = "menu"
+
+from .bridge_manager import ManagedBridgeConfig, parse_managed_bridge_configs
 from .const import (
+    ATTR_ENTRY_ID,
     CONF_ALLOWED_AREAS,
     CONF_BRIDGE_ID,
     CONF_BRIDGE_NAME,
@@ -26,6 +38,7 @@ from .const import (
     CONF_INCLUDE_ENTITIES,
     CONF_MANAGED_BRIDGES,
     DOMAIN,
+    SERVICE_SYNC,
 )
 from .exposure import build_exposure_plan
 from .storage import async_discover_bridges
@@ -121,8 +134,12 @@ class BridgeFlowMixin:
                 self._area_name_lookup[default_room_name] = default_room_name
                 default_room_key = default_room_name
 
-        include_defaults = _list_to_text(defaults.get(CONF_INCLUDE_ENTITIES, []))
-        exclude_defaults = _list_to_text(defaults.get(CONF_EXCLUDE_ENTITIES, []))
+        include_defaults = _list_to_text(
+            defaults.get(CONF_INCLUDE_ENTITIES, []),
+        )
+        exclude_defaults = _list_to_text(
+            defaults.get(CONF_EXCLUDE_ENTITIES, []),
+        )
 
         return vol.Schema(
             {
@@ -164,6 +181,7 @@ class BridgeFlowMixin:
         default_room = None
         if default_room_key:
             default_room = self._area_name_lookup.get(default_room_key)
+            registry = None
             if default_room is None:
                 area_id = self._area_id_lookup.get(default_room_key)
                 if area_id:
@@ -172,13 +190,22 @@ class BridgeFlowMixin:
                     if area_entry and area_entry.name:
                         default_room = str(area_entry.name)
             if default_room is None:
+                registry = registry or area_registry.async_get(self.hass)
+                area_entry = registry.async_get_area(default_room_key)
+                if area_entry and area_entry.name:
+                    default_room = str(area_entry.name)
+            if default_room is None:
                 default_room = default_room_key
 
-        include_entities = _parse_entity_text(user_input.get(CONF_INCLUDE_ENTITIES))
+        include_entities = _parse_entity_text(
+            user_input.get(CONF_INCLUDE_ENTITIES),
+        )
         include_set = set(include_entities)
         exclude_entities = [
             entity
-            for entity in _parse_entity_text(user_input.get(CONF_EXCLUDE_ENTITIES))
+            for entity in _parse_entity_text(
+                user_input.get(CONF_EXCLUDE_ENTITIES)
+            )
             if entity not in include_set
         ]
 
@@ -206,7 +233,11 @@ class BridgeFlowMixin:
         defaults = self._existing_bridge_map.get(bridge_id, {})
 
         if user_input is not None:
-            payload = self._serialize_bridge_input(bridge_id, friendly_name, user_input)
+            payload = self._serialize_bridge_input(
+                bridge_id,
+                friendly_name,
+                user_input,
+            )
             self._bridge_payloads.append(payload)
             self._bridge_form_index += 1
 
@@ -226,7 +257,7 @@ class BridgeFlowMixin:
             },
         )
 
-    async def _finish_bridge_flow(self) -> ConfigFlowResult:  # pragma: no cover - overridden
+    async def _finish_bridge_flow(self) -> ConfigFlowResult:
         raise NotImplementedError
 
     def _log_exposure_preview(self, payloads: list[dict[str, Any]]) -> None:
@@ -329,12 +360,18 @@ class HomeKitRoomSyncConfigFlow(
     ) -> ConfigFlowResult:
         return await self._async_handle_bridge_step("bridge", user_input)
 
+    @staticmethod
+    def is_matching(*_: Any, **__: Any) -> bool:
+        """Return whether this flow matches a discovery (unused)."""
+        return False
+
     async def _finish_bridge_flow(self) -> ConfigFlowResult:
         if not self._bridge_payloads:
             return self.async_abort(reason="no_bridges")
 
         if len(self._bridge_payloads) == 1:
-            title = f"HomeKit Bridge: {self._bridge_payloads[0][CONF_BRIDGE_TITLE]}"
+            bridge_title = self._bridge_payloads[0][CONF_BRIDGE_TITLE]
+            title = f"HomeKit Bridge: {bridge_title}"
         else:
             title = f"HomeKit Room Sync ({len(self._bridge_payloads)} bridges)"
 
@@ -352,7 +389,51 @@ class HomeKitRoomSyncOptionsFlow(BridgeFlowMixin, OptionsFlow):
         OptionsFlow.__init__(self, config_entry)
         BridgeFlowMixin.__init__(self)
 
+    def _show_menu(self, **kwargs: Any) -> ConfigFlowResult:
+        """Show a menu, using HA's helper when available."""
+        try:
+            return super().async_show_menu(**kwargs)  # type: ignore[attr-defined]
+        except AttributeError:
+            return {
+                "type": FlowResultType.MENU,
+                "step_id": kwargs.get("step_id", "init"),
+                "menu_options": kwargs.get("menu_options", []),
+                "description_placeholders": kwargs.get(
+                    "description_placeholders", {}
+                ),
+            }
+
+    def async_show_menu(self, *args: Any, **kwargs: Any) -> ConfigFlowResult:
+        """Return a menu result (compat shim for tests and HA)."""
+        step_id = kwargs.get("step_id") or (args[0] if args else "init")
+        menu_options = kwargs.get("menu_options") or (
+            args[1] if len(args) > 1 else []
+        )
+        description_placeholders = kwargs.get("description_placeholders") or {}
+        return {
+            "type": FlowResultType.MENU,
+            "step_id": step_id,
+            "menu_options": menu_options,
+            "description_placeholders": description_placeholders,
+        }
+
     async def async_step_init(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        if user_input is not None:
+            next_step = user_input.get("next_step_id")
+            if next_step == "configure":
+                return await self.async_step_configure()
+            if next_step == "resync":
+                return await self.async_step_resync()
+
+        return self._show_menu(
+            step_id="init",
+            menu_options=["configure", "resync"],
+        )
+
+    async def async_step_configure(
         self,
         user_input: dict[str, Any] | None = None,
     ) -> ConfigFlowResult:
@@ -423,7 +504,7 @@ class HomeKitRoomSyncOptionsFlow(BridgeFlowMixin, OptionsFlow):
             }
         )
         return self.async_show_form(
-            step_id="init",
+            step_id="configure",
             data_schema=schema,
             errors=errors,
             description_placeholders={
@@ -446,5 +527,52 @@ class HomeKitRoomSyncOptionsFlow(BridgeFlowMixin, OptionsFlow):
         self.hass.config_entries.async_update_entry(
             self.config_entry,
             data=new_data,
+        )
+        return self.async_create_entry(title="", data={})
+
+    async def async_step_resync(
+        self,
+        user_input: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        bridge_configs = parse_managed_bridge_configs(self.config_entry)
+        if not bridge_configs:
+            return self.async_abort(reason="no_bridges")
+
+        if user_input is None:
+            summaries: list[str] = []
+            for config in bridge_configs:
+                plan = build_exposure_plan(self.hass, config)
+                preview = ", ".join(plan.include_entities[:5])
+                if len(plan.include_entities) > 5:
+                    preview = f"{preview}, …"
+                summaries.append(
+                    f"{config.title}: {len(plan.include_entities)} entities"
+                    f"{f' ({preview})' if preview else ''}"
+                )
+
+            summary = (
+                "\n".join(summaries) if summaries else "No entities to expose."
+            )
+
+            return self.async_show_form(
+                step_id="resync",
+                data_schema=vol.Schema({}),
+                description_placeholders={
+                    "summary": summary,
+                },
+            )
+
+        if domain_data := self.hass.data.get(DOMAIN):
+            if entry_data := domain_data.get(self.config_entry.entry_id):
+                manager = entry_data.get("manager")
+                if manager is not None:
+                    await manager.async_sync()
+                    return self.async_create_entry(title="", data={})
+
+        await self.hass.services.async_call(
+            DOMAIN,
+            SERVICE_SYNC,
+            {ATTR_ENTRY_ID: self.config_entry.entry_id},
+            blocking=True,
         )
         return self.async_create_entry(title="", data={})

--- a/custom_components/homekit_room_sync/config_flow.py
+++ b/custom_components/homekit_room_sync/config_flow.py
@@ -320,8 +320,7 @@ class HomeKitRoomSyncOptionsFlow(BridgeFlowMixin, OptionsFlow):
     """Handle options flow for HomeKit Room Sync."""
 
     def __init__(self, config_entry: ConfigEntry) -> None:
-        self.config_entry = config_entry
-        OptionsFlow.__init__(self, config_entry)
+        self._config_entry = config_entry
         BridgeFlowMixin.__init__(self)
 
     async def async_step_init(

--- a/custom_components/homekit_room_sync/const.py
+++ b/custom_components/homekit_room_sync/const.py
@@ -7,8 +7,13 @@ DOMAIN: Final = "homekit_room_sync"
 
 # Configuration keys
 CONF_BRIDGE_NAME: Final = "bridge_name"
+CONF_BRIDGE_ID: Final = "bridge_id"
+CONF_BRIDGE_TITLE: Final = "bridge_title"
 CONF_DEFAULT_ROOM: Final = "default_room"
 CONF_ALLOWED_AREAS: Final = "allowed_areas"
+CONF_MANAGED_BRIDGES: Final = "managed_bridges"
+CONF_INCLUDE_ENTITIES: Final = "include_entities"
+CONF_EXCLUDE_ENTITIES: Final = "exclude_entities"
 
 # HomeKit storage patterns
 HOMEKIT_STORAGE_PREFIX: Final = "homekit."
@@ -19,6 +24,7 @@ HOMEKIT_IIDS_SUFFIX: Final = ".iids"
 # Event types to listen for
 EVENT_ENTITY_REGISTRY_UPDATED: Final = "entity_registry_updated"
 EVENT_AREA_REGISTRY_UPDATED: Final = "area_registry_updated"
+EVENT_DEVICE_REGISTRY_UPDATED: Final = "device_registry_updated"
 
 # Debounce delay in seconds
 SYNC_DEBOUNCE_DELAY: Final = 0.5
@@ -29,6 +35,10 @@ SERVICE_RELOAD: Final = "reload"
 
 # Services
 SERVICE_SYNC: Final = "sync"
+
+# Service attributes
+ATTR_ENTRY_ID: Final = "entry_id"
+ATTR_BRIDGE_ID: Final = "bridge_id"
 # Storage keys used in HomeKit state files
 STORAGE_KEY_ACCESSORIES: Final = "accessories"
 STORAGE_KEY_ENTITY_ID: Final = "entity_id"

--- a/custom_components/homekit_room_sync/const.py
+++ b/custom_components/homekit_room_sync/const.py
@@ -29,9 +29,8 @@ EVENT_DEVICE_REGISTRY_UPDATED: Final = "device_registry_updated"
 # Debounce delay in seconds
 SYNC_DEBOUNCE_DELAY: Final = 0.5
 
-# HomeKit service
+# HomeKit domain
 HOMEKIT_DOMAIN: Final = "homekit"
-SERVICE_RELOAD: Final = "reload"
 
 # Services
 SERVICE_SYNC: Final = "sync"
@@ -39,7 +38,3 @@ SERVICE_SYNC: Final = "sync"
 # Service attributes
 ATTR_ENTRY_ID: Final = "entry_id"
 ATTR_BRIDGE_ID: Final = "bridge_id"
-# Storage keys used in HomeKit state files
-STORAGE_KEY_ACCESSORIES: Final = "accessories"
-STORAGE_KEY_ENTITY_ID: Final = "entity_id"
-STORAGE_KEY_ROOM_NAME: Final = "room_name"

--- a/custom_components/homekit_room_sync/coordinator.py
+++ b/custom_components/homekit_room_sync/coordinator.py
@@ -1,16 +1,9 @@
-"""Coordinator for HomeKit Room Sync integration.
-
-This module handles reading and writing HomeKit Bridge storage files,
-mapping entity areas to HomeKit rooms, and triggering bridge reloads.
-"""
+"""Coordinator for HomeKit Room Sync integration."""
 
 from __future__ import annotations
 
 import asyncio
-import json
 import logging
-import shutil
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -22,21 +15,16 @@ from homeassistant.helpers import (
 )
 
 from .const import (
-    CONF_BRIDGE_NAME,
-    CONF_ALLOWED_AREAS,
-    CONF_DEFAULT_ROOM,
     HOMEKIT_DOMAIN,
-    HOMEKIT_AIDS_SUFFIX,
-    HOMEKIT_IIDS_SUFFIX,
-    HOMEKIT_STORAGE_PREFIX,
-    HOMEKIT_STORAGE_SUFFIX,
     SERVICE_RELOAD,
     STORAGE_KEY_ACCESSORIES,
     STORAGE_KEY_ENTITY_ID,
     STORAGE_KEY_ROOM_NAME,
 )
+from .storage import HomeKitStorageClient
 
 if TYPE_CHECKING:
+    from .bridge_manager import ManagedBridgeConfig
     from homeassistant.helpers.area_registry import AreaRegistry
     from homeassistant.helpers.device_registry import DeviceRegistry
     from homeassistant.helpers.entity_registry import EntityRegistry
@@ -45,205 +33,183 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class HomeKitRoomSyncCoordinator:
-    """Coordinator class that manages HomeKit room synchronization.
+    """Synchronize Home Assistant areas and HomeKit room assignments."""
 
-    This coordinator reads HomeKit Bridge state files, determines the
-    appropriate room for each exposed entity based on its Home Assistant
-    area, and updates the storage files accordingly.
-    """
-
-    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
-        """Initialize the coordinator.
-
-        Args:
-            hass: The Home Assistant instance.
-            entry: The config entry for this integration.
-        """
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        config: ManagedBridgeConfig,
+        storage: HomeKitStorageClient,
+    ) -> None:
+        """Initialize the coordinator."""
         self.hass = hass
         self.entry = entry
-        self._bridge_name: str = entry.data[CONF_BRIDGE_NAME]
-        self._default_room: str | None = entry.data.get(CONF_DEFAULT_ROOM)
-        self._allowed_areas: set[str] = set(
-            entry.data.get(CONF_ALLOWED_AREAS, []) or []
-        )
-        self._storage_path: Path = Path(hass.config.path()) / ".storage"
+        self.config = config
+        self._storage = storage
+        self._state_path = storage.state_path(config.bridge_id)
+        self._aids_path = storage.aids_path(config.bridge_id)
+        self._iids_path = storage.iids_path(config.bridge_id)
         self._sync_lock = asyncio.Lock()
 
     @property
-    def bridge_storage_file(self) -> Path:
-        """Get the path to the HomeKit bridge state file.
-
-        Returns:
-            Path to the bridge's state file in .storage directory.
-        """
-        filename = (
-            f"{HOMEKIT_STORAGE_PREFIX}"
-            f"{self._bridge_name}"
-            f"{HOMEKIT_STORAGE_SUFFIX}"
-        )
-        return self._storage_path / filename
+    def bridge_storage_file(self):
+        """Return the primary storage path (legacy compatibility)."""
+        return self._state_path
 
     async def async_sync_rooms(self) -> bool:
-        """Synchronize Home Assistant areas to HomeKit rooms.
-
-        This method reads the HomeKit bridge state file, updates room
-        assignments based on entity areas, and writes the changes back.
-
-        Returns:
-            True if sync was successful, False otherwise.
-        """
+        """Synchronize HomeKit state."""
         async with self._sync_lock:
             return await self._perform_sync()
 
     async def _perform_sync(self) -> bool:
-        """Perform the actual sync operation (internal, lock must be held).
-
-        Returns:
-            True if sync was successful, False otherwise.
-        """
-        storage_file = self.bridge_storage_file
-
-        # Check if the storage file exists
-        if not await self._file_exists(storage_file):
+        if not await self._storage.exists(self._state_path):
             _LOGGER.warning(
-                "HomeKit bridge storage file not found: %s",
-                storage_file,
+                "HomeKit bridge storage file not found for %s (%s)",
+                self.config.title,
+                self._state_path,
             )
             return False
 
         aids_changes = await self._sync_allocations()
 
-        try:
-            # Read the current storage data
-            storage_data = await self._read_storage_file(storage_file)
-            if storage_data is None:
-                return False
+        storage_data = await self._storage.read(self._state_path)
+        if storage_data is None:
+            return False
 
-            # Get registries for area lookups
-            entity_reg = entity_registry.async_get(self.hass)
-            device_reg = device_registry.async_get(self.hass)
-            area_reg = area_registry.async_get(self.hass)
+        entity_reg = entity_registry.async_get(self.hass)
+        device_reg = device_registry.async_get(self.hass)
+        area_reg = area_registry.async_get(self.hass)
 
-            # Track if any changes were made
-            changes_made = False
+        accessories = storage_data.get("data", {}).get(
+            STORAGE_KEY_ACCESSORIES,
+            [],
+        )
 
-            removed_entities: list[str] = []
-            updated_accessories: list[dict[str, Any]] = []
-
-            # Process accessories and update room assignments
-            if STORAGE_KEY_ACCESSORIES in storage_data.get("data", {}):
-                accessories = storage_data["data"][STORAGE_KEY_ACCESSORIES]
-                for accessory in accessories:
-                    entity_id = accessory.get(STORAGE_KEY_ENTITY_ID)
-                    if not entity_id:
-                        updated_accessories.append(accessory)
-                        continue
-
-                    area_id, resolved_room = self._resolve_area_and_room(
-                        entity_id,
-                        entity_reg,
-                        device_reg,
-                        area_reg,
-                    )
-
-                    if (
-                        self._allowed_areas
-                        and area_id not in self._allowed_areas
-                    ):
-                        removed_entities.append(entity_id)
-                        changes_made = True
-                        _LOGGER.debug(
-                            "Skipping %s; area %s not allowed for bridge %s",
-                            entity_id,
-                            area_id,
-                            self._bridge_name,
-                        )
-                        continue
-
-                    room_name = resolved_room or self._default_room
-
-                    # Update room if it changed
-                    current_room = accessory.get(STORAGE_KEY_ROOM_NAME)
-                    if room_name and room_name != current_room:
-                        accessory[STORAGE_KEY_ROOM_NAME] = room_name
-                        changes_made = True
-                        _LOGGER.debug(
-                            "Updated room for %s: %s -> %s",
-                            entity_id,
-                            current_room,
-                            room_name,
-                        )
-                    updated_accessories.append(accessory)
-
-            if removed_entities:
-                storage_data["data"][STORAGE_KEY_ACCESSORIES] = (
-                    updated_accessories
-                )
-                _LOGGER.info(
-                    "Removed %s accessories outside allowed areas for %s: %s",
-                    len(removed_entities),
-                    self._bridge_name,
-                    ", ".join(sorted(removed_entities)),
-                )
-
-            if changes_made:
-                # Create backup before writing
-                await self._create_backup(storage_file)
-
-                # Write updated data
-                if await self._write_storage_file(storage_file, storage_data):
-                    _LOGGER.info(
-                        "Successfully synced rooms for bridge: %s",
-                        self._bridge_name,
-                    )
-                    # Trigger HomeKit reload
-                    await self._reload_homekit()
-                    return True
-                return False
-
-            _LOGGER.debug(
-                "No room changes needed for bridge: %s",
-                self._bridge_name,
-            )
-            return True if not aids_changes else await self._reload_after_alloc()
-
-        except Exception as err:
-            _LOGGER.exception(
-                "Error syncing rooms for bridge %s: %s",
-                self._bridge_name,
-                err,
+        if not isinstance(accessories, list):
+            _LOGGER.warning(
+                "Unexpected accessories structure for bridge %s",
+                self.config.title,
             )
             return False
 
+        updated_accessories: list[dict[str, Any]] = []
+        removed_entities: list[str] = []
+        changes_made = False
+
+        for accessory in accessories:
+            entity_id = accessory.get(STORAGE_KEY_ENTITY_ID)
+            if not entity_id:
+                updated_accessories.append(accessory)
+                continue
+
+            area_id, resolved_room = self._resolve_area_and_room(
+                entity_id,
+                entity_reg,
+                device_reg,
+                area_reg,
+            )
+
+            include_override = entity_id in self.config.include_entities
+            exclude_override = entity_id in self.config.exclude_entities
+
+            if exclude_override:
+                removed_entities.append(entity_id)
+                changes_made = True
+                _LOGGER.debug(
+                    "Excluded %s from HomeKit bridge %s via override",
+                    entity_id,
+                    self.config.title,
+                )
+                continue
+
+            if not self._should_include(area_id, include_override):
+                removed_entities.append(entity_id)
+                changes_made = True
+                _LOGGER.debug(
+                    "Removed %s; area %s not allowed for bridge %s",
+                    entity_id,
+                    area_id,
+                    self.config.title,
+                )
+                continue
+
+            room_name = resolved_room or self.config.default_room
+            if include_override and not room_name:
+                room_name = self.config.default_room
+
+            current_room = accessory.get(STORAGE_KEY_ROOM_NAME)
+            if room_name and room_name != current_room:
+                accessory[STORAGE_KEY_ROOM_NAME] = room_name
+                changes_made = True
+                _LOGGER.debug(
+                    "Updated room for %s on bridge %s: %s -> %s",
+                    entity_id,
+                    self.config.title,
+                    current_room,
+                    room_name,
+                )
+
+            updated_accessories.append(accessory)
+
+        if removed_entities:
+            storage_data["data"][STORAGE_KEY_ACCESSORIES] = updated_accessories
+            _LOGGER.info(
+                "Filtered %s accessories for bridge %s: %s",
+                len(removed_entities),
+                self.config.title,
+                ", ".join(sorted(removed_entities)),
+            )
+
+        if changes_made:
+            await self._storage.backup(self._state_path)
+            if not await self._storage.write(self._state_path, storage_data):
+                return False
+            await self._reload_homekit()
+            return True
+
+        _LOGGER.debug(
+            "No storage changes required for bridge %s",
+            self.config.title,
+        )
+        return True if not aids_changes else await self._reload_after_alloc()
+
+    def _should_include(self, area_id: str | None, include_override: bool) -> bool:
+        """Return True if an entity should remain exposed."""
+        if include_override:
+            return True
+        if not self.config.allowed_areas:
+            return True
+        return bool(area_id and area_id in self.config.allowed_areas)
+
     async def _reload_after_alloc(self) -> bool:
-        """Reload HomeKit after allocation changes."""
         try:
             await self._reload_homekit()
         except Exception as err:  # noqa: BLE001
-            _LOGGER.warning("Failed to reload HomeKit after alloc update: %s", err)
+            _LOGGER.warning(
+                "Failed to reload HomeKit after allocation update for %s: %s",
+                self.config.title,
+                err,
+            )
             return False
         return True
 
     async def _sync_allocations(self) -> bool:
-        """Synchronize HomeKit allocation files (.aids/.iids) with allowed areas."""
-        if not self._allowed_areas:
+        """Update aids/iids allocations when filters change."""
+        if not self.config.allowed_areas:
             return False
 
-        aids_path = self._storage_path / (
-            f"{HOMEKIT_STORAGE_PREFIX}{self._bridge_name}{HOMEKIT_AIDS_SUFFIX}"
-        )
-        iids_path = self._storage_path / (
-            f"{HOMEKIT_STORAGE_PREFIX}{self._bridge_name}{HOMEKIT_IIDS_SUFFIX}"
-        )
-
-        if not await self._file_exists(aids_path):
+        if not await self._storage.exists(self._aids_path):
             return False
 
-        aids_data = await self._read_storage_file(aids_path)
+        aids_data = await self._storage.read(self._aids_path)
         if aids_data is None:
             return False
 
-        allocations: dict[str, int] = aids_data.get("data", {}).get("allocations", {})
+        allocations: dict[str, int] = aids_data.get("data", {}).get(
+            "allocations",
+            {},
+        )
         if not allocations:
             return False
 
@@ -265,6 +231,14 @@ class HomeKitRoomSyncCoordinator:
                 None,
             )
 
+            entity_id = entity_entry.entity_id if entity_entry else None
+            if entity_id and entity_id in self.config.exclude_entities:
+                removed[key] = aid
+                continue
+            if entity_id and entity_id in self.config.include_entities:
+                kept[key] = aid
+                continue
+
             area_id = None
             if entity_entry:
                 area_id = entity_entry.area_id
@@ -274,7 +248,7 @@ class HomeKitRoomSyncCoordinator:
                         area_id = device_entry.area_id
 
             if area_id and area_reg.async_get_area(area_id):
-                if area_id in self._allowed_areas:
+                if area_id in self.config.allowed_areas:
                     kept[key] = aid
                     continue
 
@@ -284,26 +258,24 @@ class HomeKitRoomSyncCoordinator:
             return False
 
         aids_data["data"]["allocations"] = kept
-        await self._create_backup(aids_path)
-        if not await self._write_storage_file(aids_path, aids_data):
+        await self._storage.backup(self._aids_path)
+        if not await self._storage.write(self._aids_path, aids_data):
             return False
 
-        if await self._file_exists(iids_path):
-            iids_data = await self._read_storage_file(iids_path)
+        if await self._storage.exists(self._iids_path):
+            iids_data = await self._storage.read(self._iids_path)
             if iids_data and "data" in iids_data and "allocations" in iids_data["data"]:
                 allocs = iids_data["data"]["allocations"]
                 for aid in removed.values():
                     allocs.pop(str(aid), None)
-                await self._create_backup(iids_path)
-                await self._write_storage_file(iids_path, iids_data)
+                await self._storage.backup(self._iids_path)
+                await self._storage.write(self._iids_path, iids_data)
 
         _LOGGER.info(
-            "Removed %s allocations outside allowed areas for bridge %s",
+            "Pruned %s HomeKit allocations for bridge %s",
             len(removed),
-            self._bridge_name,
+            self.config.title,
         )
-        _LOGGER.debug("Removed allocations: %s", ", ".join(sorted(removed)))
-
         await self._reload_homekit()
         return True
 
@@ -314,7 +286,6 @@ class HomeKitRoomSyncCoordinator:
         device_reg: DeviceRegistry,
         area_reg: AreaRegistry,
     ) -> tuple[str | None, str | None]:
-        """Resolve area_id and room name for an entity."""
         entity_entry = entity_reg.async_get(entity_id)
         if entity_entry is None:
             return None, None
@@ -343,233 +314,21 @@ class HomeKitRoomSyncCoordinator:
         device_reg: DeviceRegistry,
         area_reg: AreaRegistry,
     ) -> str | None:
-        """Determine the HomeKit room name for an entity.
-
-        The lookup priority is:
-        1. Entity's directly assigned area
-        2. Entity's device area
-        3. Default room configured for this bridge
-
-        Args:
-            entity_id: The entity ID to look up.
-            entity_reg: The entity registry.
-            device_reg: The device registry.
-            area_reg: The area registry.
-
-        Returns:
-            The room name, or None if no area could be determined.
-        """
         _area_id, room_name = self._resolve_area_and_room(
-            entity_id, entity_reg, device_reg, area_reg
+            entity_id,
+            entity_reg,
+            device_reg,
+            area_reg,
         )
-        if room_name:
-            return room_name
-
-        # Fall back to default room
-        return self._default_room
-
-    async def _file_exists(self, path: Path) -> bool:
-        """Check if a file exists asynchronously.
-
-        Args:
-            path: The path to check.
-
-        Returns:
-            True if the file exists, False otherwise.
-        """
-        result = await self.hass.async_add_executor_job(path.exists)
-        return bool(result)
-
-    async def _read_storage_file(self, path: Path) -> dict[str, Any] | None:
-        """Read and parse a JSON storage file.
-
-        Args:
-            path: The path to the storage file.
-
-        Returns:
-            Parsed JSON data, or None if reading failed.
-        """
-        try:
-            content = await self.hass.async_add_executor_job(path.read_text)
-            data = json.loads(content)
-
-            # Validate basic structure
-            if not isinstance(data, dict):
-                _LOGGER.error("Invalid storage file structure: %s", path)
-                return None
-
-            # Handle standard HA storage format (wrapped in "data")
-            if "data" in data:
-                return data
-
-            # Handle flat format (no "data" wrapper)
-            _LOGGER.debug("Storage missing 'data' key, wrapping: %s", path)
-            return {"data": data}
-        except json.JSONDecodeError as err:
-            _LOGGER.error("Failed to parse storage file %s: %s", path, err)
-            return None
-        except OSError as err:
-            _LOGGER.error("Failed to read storage file %s: %s", path, err)
-            return None
-
-    async def _write_storage_file(
-        self,
-        path: Path,
-        data: dict[str, Any],
-    ) -> bool:
-        """Write data to a storage file.
-
-        Args:
-            path: The path to write to.
-            data: The data to write.
-
-        Returns:
-            True if writing succeeded, False otherwise.
-        """
-        try:
-            content = json.dumps(data, indent=2, ensure_ascii=False)
-            await self.hass.async_add_executor_job(path.write_text, content)
-            return True
-        except (OSError, TypeError) as err:
-            _LOGGER.error("Failed to write storage file %s: %s", path, err)
-            return False
-
-    async def _create_backup(self, path: Path) -> bool:
-        """Create a backup of the storage file before modification.
-
-        Args:
-            path: The path to the file to backup.
-
-        Returns:
-            True if backup succeeded, False otherwise.
-        """
-        backup_path = path.with_suffix(f"{path.suffix}.backup")
-        try:
-            await self.hass.async_add_executor_job(
-                shutil.copy2,
-                path,
-                backup_path,
-            )
-            _LOGGER.debug("Created backup: %s", backup_path)
-            return True
-        except OSError as err:
-            _LOGGER.warning("Failed to create backup %s: %s", backup_path, err)
-            return False
+        return room_name or self.config.default_room
 
     async def _reload_homekit(self) -> None:
-        """Trigger a HomeKit bridge reload to apply changes."""
         try:
             await self.hass.services.async_call(
                 HOMEKIT_DOMAIN,
                 SERVICE_RELOAD,
                 blocking=True,
             )
-            _LOGGER.debug("HomeKit reload triggered successfully")
-        except Exception as err:
-            _LOGGER.warning("Failed to reload HomeKit: %s", err)
-
-    @classmethod
-    def get_available_bridges(cls, hass: HomeAssistant) -> dict[str, str]:
-        """Get a map of available HomeKit bridges from storage.
-
-        This method scans the .storage directory for HomeKit bridge
-        state files and maps them to their friendly names from config entries.
-
-        Args:
-            hass: The Home Assistant instance.
-
-        Returns:
-            Dictionary mapping bridge ID to friendly name.
-        """
-        storage_path = Path(hass.config.path()) / ".storage"
-        bridges: dict[str, str] = {}
-
-        if not storage_path.exists():
-            return bridges
-
-        # Get all HomeKit config entries for name lookup
-        hk_entries = {}
-        for entry in hass.config_entries.async_entries(HOMEKIT_DOMAIN):
-            # Prefer the UI title, then data["name"]
-            name = entry.title or entry.data.get("name") or "Unknown Bridge"
-            hk_entries[entry.entry_id] = name
-
-        for file in storage_path.iterdir():
-            if (
-                file.is_file()
-                and file.name.startswith(HOMEKIT_STORAGE_PREFIX)
-                and file.name.endswith(HOMEKIT_STORAGE_SUFFIX)
-            ):
-                # Extract bridge ID from filename
-                # Format: homekit.{entry_id}.state
-                prefix_len = len(HOMEKIT_STORAGE_PREFIX)
-                suffix_len = len(HOMEKIT_STORAGE_SUFFIX)
-                entry_id = file.name[prefix_len:-suffix_len]
-
-                if entry_id:
-                    # Prefer name stored in the HomeKit state file
-                    # (reflects renames inside HomeKit UI)
-                    friendly_name = cls._extract_name_from_storage(file)
-
-                    # Fallback to HomeKit config entry name
-                    if not friendly_name:
-                        friendly_name = hk_entries.get(entry_id)
-
-                    # Final fallback to ID-based name
-                    if not friendly_name:
-                        friendly_name = f"Bridge {entry_id}"
-
-                    bridges[entry_id] = friendly_name
-
-        return bridges
-
-    @staticmethod
-    def _extract_name_from_storage(path: Path) -> str | None:
-        """Try to read the bridge's friendly name from its storage file."""
-        try:
-            content = json.loads(path.read_text())
-        except (OSError, json.JSONDecodeError):
-            return None
-
-        data = (
-            content.get("data", content)
-            if isinstance(content, dict)
-            else None
-        )
-        if isinstance(data, dict):
-            config_section = (
-                data.get("config")
-                if isinstance(data.get("config"), dict)
-                else {}
-            )
-            bridge_section = (
-                data.get("bridge")
-                if isinstance(data.get("bridge"), dict)
-                else {}
-            )
-            if _LOGGER.isEnabledFor(logging.DEBUG):
-                _LOGGER.debug(
-                    (
-                        "HomeKit storage structure for %s: top_keys=%s, "
-                        "data_keys=%s, config_keys=%s, bridge_keys=%s"
-                    ),
-                    path.name,
-                    (
-                        list(content.keys())
-                        if isinstance(content, dict)
-                        else "n/a"
-                    ),
-                    list(data.keys()),
-                    list(config_section.keys()),
-                    list(bridge_section.keys()),
-                )
-            name_candidates = [
-                data.get("name"),
-                data.get("bridge_name"),
-                config_section.get("name"),
-                bridge_section.get("name"),
-            ]
-            for name in name_candidates:
-                if isinstance(name, str) and name.strip():
-                    return name.strip()
-        return None
+            _LOGGER.debug("Triggered HomeKit reload for %s", self.config.title)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.warning("Failed to reload HomeKit for %s: %s", self.config.title, err)

--- a/custom_components/homekit_room_sync/coordinator.py
+++ b/custom_components/homekit_room_sync/coordinator.py
@@ -8,327 +8,145 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import (
-    area_registry,
-    device_registry,
-    entity_registry,
-)
 
-from .const import (
-    HOMEKIT_DOMAIN,
-    SERVICE_RELOAD,
-    STORAGE_KEY_ACCESSORIES,
-    STORAGE_KEY_ENTITY_ID,
-    STORAGE_KEY_ROOM_NAME,
-)
-from .storage import HomeKitStorageClient
+from .exposure import ExposurePlan, build_exposure_plan
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
+    from homeassistant.config_entries import ConfigEntry as HACoreConfigEntry
+
     from .bridge_manager import ManagedBridgeConfig
-    from homeassistant.helpers.area_registry import AreaRegistry
-    from homeassistant.helpers.device_registry import DeviceRegistry
-    from homeassistant.helpers.entity_registry import EntityRegistry
+
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class HomeKitRoomSyncCoordinator:
-    """Synchronize Home Assistant areas and HomeKit room assignments."""
+    """Synchronize Home Assistant area filters with a HomeKit bridge."""
 
     def __init__(
         self,
         hass: HomeAssistant,
         entry: ConfigEntry,
-        config: ManagedBridgeConfig,
-        storage: HomeKitStorageClient,
+        config: "ManagedBridgeConfig",
+        _storage_client: Any | None = None,
     ) -> None:
-        """Initialize the coordinator."""
         self.hass = hass
         self.entry = entry
         self.config = config
-        self._storage = storage
-        self._state_path = storage.state_path(config.bridge_id)
-        self._aids_path = storage.aids_path(config.bridge_id)
-        self._iids_path = storage.iids_path(config.bridge_id)
         self._sync_lock = asyncio.Lock()
 
-    @property
-    def bridge_storage_file(self):
-        """Return the primary storage path (legacy compatibility)."""
-        return self._state_path
-
     async def async_sync_rooms(self) -> bool:
-        """Synchronize HomeKit state."""
+        """Run a synchronization cycle for this bridge."""
         async with self._sync_lock:
             return await self._perform_sync()
 
     async def _perform_sync(self) -> bool:
-        if not await self._storage.exists(self._state_path):
+        homekit_entry = self._get_homekit_entry()
+        if homekit_entry is None:
             _LOGGER.warning(
-                "HomeKit bridge storage file not found for %s (%s)",
+                "HomeKit bridge %s (%s) not found; skipping sync",
                 self.config.title,
-                self._state_path,
+                self.config.bridge_id,
             )
             return False
 
-        aids_changes = await self._sync_allocations()
-
-        storage_data = await self._storage.read(self._state_path)
-        if storage_data is None:
-            return False
-
-        entity_reg = entity_registry.async_get(self.hass)
-        device_reg = device_registry.async_get(self.hass)
-        area_reg = area_registry.async_get(self.hass)
-
-        accessories = storage_data.get("data", {}).get(
-            STORAGE_KEY_ACCESSORIES,
-            [],
-        )
-
-        if not isinstance(accessories, list):
+        plan = build_exposure_plan(self.hass, self.config)
+        if not plan.allowed_entities:
             _LOGGER.warning(
-                "Unexpected accessories structure for bridge %s",
+                "HomeKit bridge %s currently has no entities to expose using the configured filters",
                 self.config.title,
             )
-            return False
 
-        updated_accessories: list[dict[str, Any]] = []
-        removed_entities: list[str] = []
-        changes_made = False
-
-        for accessory in accessories:
-            entity_id = accessory.get(STORAGE_KEY_ENTITY_ID)
-            if not entity_id:
-                updated_accessories.append(accessory)
-                continue
-
-            area_id, resolved_room = self._resolve_area_and_room(
-                entity_id,
-                entity_reg,
-                device_reg,
-                area_reg,
-            )
-
-            include_override = entity_id in self.config.include_entities
-            exclude_override = entity_id in self.config.exclude_entities
-
-            if exclude_override:
-                removed_entities.append(entity_id)
-                changes_made = True
-                _LOGGER.debug(
-                    "Excluded %s from HomeKit bridge %s via override",
-                    entity_id,
-                    self.config.title,
-                )
-                continue
-
-            if not self._should_include(area_id, include_override):
-                removed_entities.append(entity_id)
-                changes_made = True
-                _LOGGER.debug(
-                    "Removed %s; area %s not allowed for bridge %s",
-                    entity_id,
-                    area_id,
-                    self.config.title,
-                )
-                continue
-
-            room_name = resolved_room or self.config.default_room
-            if include_override and not room_name:
-                room_name = self.config.default_room
-
-            current_room = accessory.get(STORAGE_KEY_ROOM_NAME)
-            if room_name and room_name != current_room:
-                accessory[STORAGE_KEY_ROOM_NAME] = room_name
-                changes_made = True
-                _LOGGER.debug(
-                    "Updated room for %s on bridge %s: %s -> %s",
-                    entity_id,
-                    self.config.title,
-                    current_room,
-                    room_name,
-                )
-
-            updated_accessories.append(accessory)
-
-        if removed_entities:
-            storage_data["data"][STORAGE_KEY_ACCESSORIES] = updated_accessories
-            _LOGGER.info(
-                "Filtered %s accessories for bridge %s: %s",
-                len(removed_entities),
-                self.config.title,
-                ", ".join(sorted(removed_entities)),
-            )
-
-        if changes_made:
-            await self._storage.backup(self._state_path)
-            if not await self._storage.write(self._state_path, storage_data):
-                return False
-            await self._reload_homekit()
+        if not self._apply_plan(homekit_entry, plan):
+            _LOGGER.debug("No HomeKit filter changes required for %s", self.config.title)
             return True
 
-        _LOGGER.debug(
-            "No storage changes required for bridge %s",
-            self.config.title,
-        )
-        return True if not aids_changes else await self._reload_after_alloc()
-
-    def _should_include(self, area_id: str | None, include_override: bool) -> bool:
-        """Return True if an entity should remain exposed."""
-        if include_override:
-            return True
-        if not self.config.allowed_areas:
-            return True
-        return bool(area_id and area_id in self.config.allowed_areas)
-
-    async def _reload_after_alloc(self) -> bool:
-        try:
-            await self._reload_homekit()
-        except Exception as err:  # noqa: BLE001
-            _LOGGER.warning(
-                "Failed to reload HomeKit after allocation update for %s: %s",
-                self.config.title,
-                err,
-            )
-            return False
+        await self.hass.config_entries.async_reload(homekit_entry.entry_id)
+        self._log_preview(plan)
         return True
 
-    async def _sync_allocations(self) -> bool:
-        """Update aids/iids allocations when filters change."""
-        if not self.config.allowed_areas:
-            return False
+    def _get_homekit_entry(self) -> "HACoreConfigEntry | None":
+        return self.hass.config_entries.async_get_entry(self.config.bridge_id)
 
-        if not await self._storage.exists(self._aids_path):
-            return False
-
-        aids_data = await self._storage.read(self._aids_path)
-        if aids_data is None:
-            return False
-
-        allocations: dict[str, int] = aids_data.get("data", {}).get(
-            "allocations",
-            {},
+    def _apply_plan(
+        self,
+        homekit_entry: "HACoreConfigEntry",
+        plan: ExposurePlan,
+    ) -> bool:
+        current_data = dict(homekit_entry.data)
+        new_filter = self._build_filter(current_data.get("filter"), plan)
+        new_entity_config = self._build_entity_config(
+            current_data.get("entity_config"),
+            plan,
         )
-        if not allocations:
+
+        changed = False
+        if not _dicts_equal(new_filter, current_data.get("filter")):
+            current_data["filter"] = new_filter
+            changed = True
+
+        if not _dicts_equal(new_entity_config, current_data.get("entity_config")):
+            current_data["entity_config"] = new_entity_config
+            changed = True
+
+        if not changed:
             return False
 
-        entity_reg = entity_registry.async_get(self.hass)
-        device_reg = device_registry.async_get(self.hass)
-        area_reg = area_registry.async_get(self.hass)
+        self.hass.config_entries.async_update_entry(homekit_entry, data=current_data)
+        return True
 
-        removed: dict[str, int] = {}
-        kept: dict[str, int] = {}
+    def _build_filter(
+        self,
+        existing: dict[str, Any] | None,
+        plan: ExposurePlan,
+    ) -> dict[str, Any]:
+        result = dict(existing or {})
+        result["include_entities"] = plan.include_entities
+        result["exclude_entities"] = plan.exclude_entities
+        result["include_areas"] = sorted(self.config.allowed_areas)
+        return result
 
-        for key, aid in allocations.items():
-            unique_id = key.split(".")[-1]
-            entity_entry = next(
-                (
-                    entry
-                    for entry in entity_reg.entities.values()
-                    if entry.unique_id == unique_id
-                ),
-                None,
-            )
+    def _build_entity_config(
+        self,
+        existing: dict[str, Any] | None,
+        plan: ExposurePlan,
+    ) -> dict[str, Any]:
+        existing = existing or {}
+        new_config: dict[str, Any] = {}
 
-            entity_id = entity_entry.entity_id if entity_entry else None
-            if entity_id and entity_id in self.config.exclude_entities:
-                removed[key] = aid
-                continue
-            if entity_id and entity_id in self.config.include_entities:
-                kept[key] = aid
-                continue
+        for entity_id in plan.allowed_entities:
+            config = dict(existing.get(entity_id, {}))
+            room = plan.rooms_by_entity.get(entity_id)
+            if room:
+                config["room"] = room
+            elif "room" in config:
+                config.pop("room")
 
-            area_id = None
-            if entity_entry:
-                area_id = entity_entry.area_id
-                if not area_id and entity_entry.device_id:
-                    device_entry = device_reg.async_get(entity_entry.device_id)
-                    if device_entry:
-                        area_id = device_entry.area_id
+            if config:
+                new_config[entity_id] = config
 
-            if area_id and area_reg.async_get_area(area_id):
-                if area_id in self.config.allowed_areas:
-                    kept[key] = aid
-                    continue
+        return new_config
 
-            removed[key] = aid
+    def _log_preview(self, plan: ExposurePlan) -> None:
+        if not plan.include_entities:
+            _LOGGER.info("Bridge %s currently exposes no entities", self.config.title)
+            return
 
-        if not removed:
-            return False
-
-        aids_data["data"]["allocations"] = kept
-        await self._storage.backup(self._aids_path)
-        if not await self._storage.write(self._aids_path, aids_data):
-            return False
-
-        if await self._storage.exists(self._iids_path):
-            iids_data = await self._storage.read(self._iids_path)
-            if iids_data and "data" in iids_data and "allocations" in iids_data["data"]:
-                allocs = iids_data["data"]["allocations"]
-                for aid in removed.values():
-                    allocs.pop(str(aid), None)
-                await self._storage.backup(self._iids_path)
-                await self._storage.write(self._iids_path, iids_data)
+        preview = ", ".join(plan.include_entities[:10])
+        if len(plan.include_entities) > 10:
+            preview = f"{preview}, …"
 
         _LOGGER.info(
-            "Pruned %s HomeKit allocations for bridge %s",
-            len(removed),
+            "Bridge %s will expose %d entities (%s)",
             self.config.title,
+            len(plan.include_entities),
+            preview,
         )
-        await self._reload_homekit()
+
+
+def _dicts_equal(first: Any | None, second: Any | None) -> bool:
+    if first is None and second is None:
         return True
-
-    def _resolve_area_and_room(
-        self,
-        entity_id: str,
-        entity_reg: EntityRegistry,
-        device_reg: DeviceRegistry,
-        area_reg: AreaRegistry,
-    ) -> tuple[str | None, str | None]:
-        entity_entry = entity_reg.async_get(entity_id)
-        if entity_entry is None:
-            return None, None
-
-        area_id: str | None = None
-
-        if entity_entry.area_id:
-            area_id = entity_entry.area_id
-        elif entity_entry.device_id:
-            device_entry = device_reg.async_get(entity_entry.device_id)
-            if device_entry and device_entry.area_id:
-                area_id = device_entry.area_id
-
-        room_name: str | None = None
-        if area_id:
-            area_entry = area_reg.async_get_area(area_id)
-            if area_entry:
-                room_name = str(area_entry.name)
-
-        return area_id, room_name
-
-    def _get_room_for_entity(
-        self,
-        entity_id: str,
-        entity_reg: EntityRegistry,
-        device_reg: DeviceRegistry,
-        area_reg: AreaRegistry,
-    ) -> str | None:
-        _area_id, room_name = self._resolve_area_and_room(
-            entity_id,
-            entity_reg,
-            device_reg,
-            area_reg,
-        )
-        return room_name or self.config.default_room
-
-    async def _reload_homekit(self) -> None:
-        try:
-            await self.hass.services.async_call(
-                HOMEKIT_DOMAIN,
-                SERVICE_RELOAD,
-                blocking=True,
-            )
-            _LOGGER.debug("Triggered HomeKit reload for %s", self.config.title)
-        except Exception as err:  # noqa: BLE001
-            _LOGGER.warning("Failed to reload HomeKit for %s: %s", self.config.title, err)
+    if first is None or second is None:
+        return False
+    return dict(first) == dict(second)

--- a/custom_components/homekit_room_sync/exposure.py
+++ b/custom_components/homekit_room_sync/exposure.py
@@ -1,0 +1,96 @@
+"""Helpers for computing HomeKit exposure plans."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import area_registry, device_registry, entity_registry
+
+if TYPE_CHECKING:
+    from .bridge_manager import ManagedBridgeConfig
+
+
+@dataclass(slots=True)
+class ExposurePlan:
+    """Describes the entities and rooms that should be exposed to HomeKit."""
+
+    allowed_entities: set[str]
+    include_entities: list[str]
+    exclude_entities: list[str]
+    rooms_by_entity: dict[str, str]
+
+
+def build_exposure_plan(
+    hass: HomeAssistant,
+    bridge: "ManagedBridgeConfig",
+) -> ExposurePlan:
+    """Compute which entities should be exposed for a bridge configuration."""
+    entity_reg = entity_registry.async_get(hass)
+    device_reg = device_registry.async_get(hass)
+    area_reg = area_registry.async_get(hass)
+
+    allowed_entities: set[str] = set()
+    rooms_by_entity: dict[str, str] = {}
+
+    for entity in entity_reg.entities.values():
+        entity_id = entity.entity_id
+        area_id = _resolve_area_id(entity, device_reg)
+
+        include = False
+        if bridge.allowed_areas:
+            include = bool(area_id and area_id in bridge.allowed_areas)
+        else:
+            include = True
+
+        if entity_id in bridge.include_entities:
+            include = True
+
+        if entity_id in bridge.exclude_entities:
+            include = False
+
+        if not include:
+            continue
+
+        allowed_entities.add(entity_id)
+        room_name = _resolve_room_name(area_id, area_reg, bridge)
+        if room_name:
+            rooms_by_entity[entity_id] = room_name
+
+    return ExposurePlan(
+        allowed_entities=allowed_entities,
+        include_entities=sorted(allowed_entities),
+        exclude_entities=sorted(bridge.exclude_entities),
+        rooms_by_entity=rooms_by_entity,
+    )
+
+
+def _resolve_area_id(entity_entry, device_reg: device_registry.DeviceRegistry) -> str | None:
+    """Resolve the most specific area_id for an entity."""
+    area_id = getattr(entity_entry, "area_id", None)
+    if area_id:
+        return area_id
+
+    device_id = getattr(entity_entry, "device_id", None)
+    if not device_id:
+        return None
+
+    device_entry = device_reg.async_get(device_id)
+    if not device_entry:
+        return None
+
+    return getattr(device_entry, "area_id", None)
+
+
+def _resolve_room_name(
+    area_id: str | None,
+    area_reg: area_registry.AreaRegistry,
+    bridge: "ManagedBridgeConfig",
+) -> str | None:
+    """Resolve the preferred room label for an entity."""
+    if area_id:
+        area = area_reg.async_get_area(area_id)
+        if area and area.name:
+            return str(area.name)
+    return bridge.default_room

--- a/custom_components/homekit_room_sync/manifest.json
+++ b/custom_components/homekit_room_sync/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "homekit_room_sync",
   "name": "HomeKit Room Sync",
-  "version": "0.0.1",
+  "version": "0.2.0",
   "codeowners": ["@lcrostarosa"],
   "config_flow": true,
   "dependencies": ["homekit"],

--- a/custom_components/homekit_room_sync/services.yaml
+++ b/custom_components/homekit_room_sync/services.yaml
@@ -1,0 +1,17 @@
+sync:
+  name: Force sync
+  description: Trigger HomeKit Room Sync for one entry or a specific bridge.
+  fields:
+    entry_id:
+      name: Config entry ID
+      description: Optional config entry ID to target a specific HomeKit Room Sync entry.
+      required: false
+      selector:
+        text:
+    bridge_id:
+      name: HomeKit bridge ID
+      description: Optional bridge ID to sync a single HomeKit bridge managed by the entry.
+      required: false
+      selector:
+        text:
+

--- a/custom_components/homekit_room_sync/storage.py
+++ b/custom_components/homekit_room_sync/storage.py
@@ -1,0 +1,167 @@
+"""Storage helpers for interacting with HomeKit files."""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    HOMEKIT_AIDS_SUFFIX,
+    HOMEKIT_DOMAIN,
+    HOMEKIT_IIDS_SUFFIX,
+    HOMEKIT_STORAGE_PREFIX,
+    HOMEKIT_STORAGE_SUFFIX,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class HomeKitStorageClient:
+    """Wrapper around Home Assistant's .storage directory."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the storage client."""
+        self._hass = hass
+        self._storage_path = Path(hass.config.path()) / ".storage"
+
+    def state_path(self, bridge_id: str) -> Path:
+        """Return the path to a bridge state file."""
+        return self._storage_path / (
+            f"{HOMEKIT_STORAGE_PREFIX}{bridge_id}{HOMEKIT_STORAGE_SUFFIX}"
+        )
+
+    def aids_path(self, bridge_id: str) -> Path:
+        """Return the path to a bridge aids file."""
+        return self._storage_path / (
+            f"{HOMEKIT_STORAGE_PREFIX}{bridge_id}{HOMEKIT_AIDS_SUFFIX}"
+        )
+
+    def iids_path(self, bridge_id: str) -> Path:
+        """Return the path to a bridge iids file."""
+        return self._storage_path / (
+            f"{HOMEKIT_STORAGE_PREFIX}{bridge_id}{HOMEKIT_IIDS_SUFFIX}"
+        )
+
+    async def exists(self, path: Path) -> bool:
+        """Check if a path exists."""
+        return bool(await self._hass.async_add_executor_job(path.exists))
+
+    async def read(self, path: Path) -> dict[str, Any] | None:
+        """Read and parse a JSON storage file."""
+        try:
+            content = await self._hass.async_add_executor_job(path.read_text)
+        except OSError as err:
+            _LOGGER.error("Failed to read storage file %s: %s", path, err)
+            return None
+
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as err:
+            _LOGGER.error("Failed to decode storage file %s: %s", path, err)
+            return None
+
+        if isinstance(data, dict) and "data" in data:
+            return data
+        if isinstance(data, dict):
+            return {"data": data}
+
+        _LOGGER.error("Unexpected structure in storage file %s", path)
+        return None
+
+    async def write(self, path: Path, data: dict[str, Any]) -> bool:
+        """Write JSON data to storage."""
+        try:
+            content = json.dumps(data, indent=2, ensure_ascii=False)
+            await self._hass.async_add_executor_job(path.write_text, content)
+            return True
+        except (OSError, TypeError) as err:
+            _LOGGER.error("Failed to write storage file %s: %s", path, err)
+            return False
+
+    async def backup(self, path: Path) -> bool:
+        """Create a backup of a storage file."""
+        backup_path = path.with_suffix(f"{path.suffix}.backup")
+
+        def _copy() -> bool:
+            try:
+                backup_path.write_text(path.read_text())
+            except OSError as err:  # noqa: BLE001
+                _LOGGER.warning(
+                    "Failed to create backup %s: %s",
+                    backup_path,
+                    err,
+                )
+                return False
+            return True
+
+        return await self._hass.async_add_executor_job(_copy)
+
+    def _extract_name_from_file(self, path: Path) -> str | None:
+        """Try to derive a friendly name from a storage file."""
+        try:
+            content = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return None
+
+        data = content.get("data", content) if isinstance(content, dict) else None
+        if not isinstance(data, dict):
+            return None
+
+        for key in ("name", "bridge_name"):
+            val = data.get(key)
+            if isinstance(val, str) and val.strip():
+                return val.strip()
+
+        for section in ("config", "bridge"):
+            section_data = data.get(section)
+            if isinstance(section_data, dict):
+                name = section_data.get("name")
+                if isinstance(name, str) and name.strip():
+                    return name.strip()
+
+        return None
+
+    def discover_bridges(self, fallback_names: dict[str, str]) -> dict[str, str]:
+        """Discover HomeKit bridges present in storage."""
+        bridges: dict[str, str] = {}
+
+        if not self._storage_path.exists():
+            return bridges
+
+        for file in self._storage_path.iterdir():
+            if (
+                not file.is_file()
+                or not file.name.startswith(HOMEKIT_STORAGE_PREFIX)
+                or not file.name.endswith(HOMEKIT_STORAGE_SUFFIX)
+            ):
+                continue
+
+            bridge_id = file.name[
+                len(HOMEKIT_STORAGE_PREFIX) : -len(HOMEKIT_STORAGE_SUFFIX)
+            ]
+            if not bridge_id:
+                continue
+
+            friendly_name = self._extract_name_from_file(file)
+            if not friendly_name:
+                friendly_name = fallback_names.get(bridge_id)
+            if not friendly_name:
+                friendly_name = f"Bridge {bridge_id}"
+
+            bridges[bridge_id] = friendly_name
+
+        return bridges
+
+
+async def async_discover_bridges(hass: HomeAssistant) -> dict[str, str]:
+    """Discover HomeKit bridges with friendly names."""
+    client = HomeKitStorageClient(hass)
+    hk_entries = {
+        entry.entry_id: entry.title or entry.data.get("name") or entry.entry_id
+        for entry in hass.config_entries.async_entries(HOMEKIT_DOMAIN)
+    }
+    return await hass.async_add_executor_job(client.discover_bridges, hk_entries)

--- a/custom_components/homekit_room_sync/strings.json
+++ b/custom_components/homekit_room_sync/strings.json
@@ -2,18 +2,20 @@
   "config": {
     "step": {
       "user": {
-        "title": "Select HomeKit Bridge",
-        "description": "Select a HomeKit Bridge to sync room assignments for. Found {bridge_count} available bridge(s).",
+        "title": "Select HomeKit Bridges",
+        "description": "Select one or more HomeKit Bridges to manage. Found {bridge_count} available bridge(s).",
         "data": {
-          "bridge_name": "HomeKit Bridge"
+          "managed_bridges": "HomeKit Bridges"
         }
       },
-      "room": {
-        "title": "Default Room",
-        "description": "Select a default room for entities in the '{bridge_name}' bridge that don't have an assigned area in Home Assistant. This is optional.",
+      "bridge": {
+        "title": "Configure {bridge_name}",
+        "description": "Step {current_index} of {bridge_total}. Choose the allowed Home Assistant Areas, optional default room label, and provide optional include/exclude entity overrides (comma or newline separated entity IDs). Include overrides always win over area filters.",
         "data": {
-          "default_room": "Default Room",
-          "allowed_areas": "Allowed Areas (optional)"
+          "allowed_areas": "Allowed Areas",
+          "default_room": "Default HomeKit Room (optional)",
+          "include_entities": "Include entity overrides",
+          "exclude_entities": "Exclude entity overrides"
         }
       }
     },
@@ -22,17 +24,27 @@
       "all_bridges_configured": "All available HomeKit Bridges have already been configured."
     },
     "error": {
-      "invalid_bridge": "The selected bridge is not valid or no longer exists."
+      "invalid_bridge": "The selected bridge is not valid or no longer exists.",
+      "select_bridge": "Select at least one bridge to continue."
     }
   },
   "options": {
     "step": {
       "init": {
-        "title": "HomeKit Room Sync Options",
-        "description": "Configure room sync options for the '{bridge_name}' bridge.",
+        "title": "Select Bridges to Manage",
+        "description": "Update which HomeKit Bridges this entry manages. Existing bridge-specific filters will be requested next.",
         "data": {
-          "default_room": "Default Room",
-          "allowed_areas": "Allowed Areas (optional)"
+          "managed_bridges": "HomeKit Bridges"
+        }
+      },
+      "bridge": {
+        "title": "Update {bridge_name}",
+        "description": "Step {current_index} of {bridge_total}. Adjust allowed areas, default room and include/exclude overrides.",
+        "data": {
+          "allowed_areas": "Allowed Areas",
+          "default_room": "Default HomeKit Room (optional)",
+          "include_entities": "Include entity overrides",
+          "exclude_entities": "Exclude entity overrides"
         }
       }
     }

--- a/custom_components/homekit_room_sync/strings.json
+++ b/custom_components/homekit_room_sync/strings.json
@@ -29,8 +29,14 @@
     }
   },
   "options": {
-    "step": {
+    "menu": {
       "init": {
+        "configure": "Configure managed bridges",
+        "resync": "Force a sync now"
+      }
+    },
+    "step": {
+      "configure": {
         "title": "Select Bridges to Manage",
         "description": "Update which HomeKit Bridges this entry manages. Existing bridge-specific filters will be requested next.",
         "data": {
@@ -46,6 +52,10 @@
           "include_entities": "Include entity overrides",
           "exclude_entities": "Exclude entity overrides"
         }
+      },
+      "resync": {
+        "title": "Force a HomeKit sync",
+        "description": "Review what will be exposed, then click submit to sync. {summary}"
       }
     }
   }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,16 @@ sys.modules["homeassistant.helpers.device_registry"] = device_registry
 sys.modules["homeassistant.helpers.entity_registry"] = entity_registry
 sys.modules["homeassistant.helpers.event"] = event
 
+from custom_components.homekit_room_sync.const import (
+    CONF_ALLOWED_AREAS,
+    CONF_BRIDGE_ID,
+    CONF_BRIDGE_TITLE,
+    CONF_DEFAULT_ROOM,
+    CONF_EXCLUDE_ENTITIES,
+    CONF_INCLUDE_ENTITIES,
+    CONF_MANAGED_BRIDGES,
+)
+
 
 @pytest.fixture
 def mock_hass() -> MagicMock:
@@ -45,8 +55,8 @@ def mock_hass() -> MagicMock:
     hass.config_entries.async_reload = AsyncMock()
 
     # Mock async_add_executor_job to run synchronously
-    async def mock_executor_job(func, *args):
-        return func(*args)
+    async def mock_executor_job(func, *args, **kwargs):
+        return func(*args, **kwargs)
 
     hass.async_add_executor_job = mock_executor_job
     return hass
@@ -58,12 +68,19 @@ def mock_config_entry() -> MagicMock:
     entry = MagicMock()
     entry.entry_id = "test_entry_id"
     entry.data = {
-        "bridge_name": "test_bridge",
-        "default_room": "Living Room",
-        "allowed_areas": [],
+        CONF_MANAGED_BRIDGES: [
+            {
+                CONF_BRIDGE_ID: "test_bridge",
+                CONF_BRIDGE_TITLE: "Test Bridge",
+                CONF_ALLOWED_AREAS: [],
+                CONF_DEFAULT_ROOM: "Living Room",
+                CONF_INCLUDE_ENTITIES: [],
+                CONF_EXCLUDE_ENTITIES: [],
+            }
+        ]
     }
-    entry.title = "HomeKit Bridge: test_bridge"
-    entry.version = 1
+    entry.title = "HomeKit Bridge: Test Bridge"
+    entry.version = 2
     entry.async_on_unload = MagicMock()
     entry.add_update_listener = MagicMock(return_value=MagicMock())
     return entry

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-import json
 import sys
-from pathlib import Path
-from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -41,7 +38,19 @@ from custom_components.homekit_room_sync.const import (
 
 
 @pytest.fixture
-def mock_hass() -> MagicMock:
+def mock_homekit_entry() -> MagicMock:
+    """Create a mock HomeKit config entry."""
+    entry = MagicMock()
+    entry.entry_id = "test_bridge"
+    entry.domain = "homekit"
+    entry.title = "Test HomeKit Bridge"
+    entry.data = {"filter": {}, "entity_config": {}}
+    entry.options = {}
+    return entry
+
+
+@pytest.fixture
+def mock_hass(mock_homekit_entry: MagicMock) -> MagicMock:
     """Create a mock Home Assistant instance."""
     hass = MagicMock()
     hass.config.path = MagicMock(return_value="/config")
@@ -53,6 +62,14 @@ def mock_hass() -> MagicMock:
     hass.services.async_register = MagicMock()
     hass.config_entries = MagicMock()
     hass.config_entries.async_reload = AsyncMock()
+    hass.config_entries.async_get_entry = MagicMock(return_value=mock_homekit_entry)
+
+    def _update_entry(entry, data=None, options=None):
+        if entry is mock_homekit_entry and data is not None:
+            mock_homekit_entry.data = data
+
+    hass.config_entries.async_update_entry = MagicMock(side_effect=_update_entry)
+    hass.config_entries.async_entries = MagicMock(return_value=[mock_homekit_entry])
 
     # Mock async_add_executor_job to run synchronously
     async def mock_executor_job(func, *args, **kwargs):
@@ -91,27 +108,32 @@ def mock_entity_registry() -> MagicMock:
     """Create a mock entity registry."""
     registry = MagicMock()
 
-    # Create mock entity entries
     entity_with_area = MagicMock()
+    entity_with_area.entity_id = "light.living_room"
     entity_with_area.area_id = "area_living_room"
     entity_with_area.device_id = None
 
     entity_with_device = MagicMock()
+    entity_with_device.entity_id = "switch.bedroom"
     entity_with_device.area_id = None
     entity_with_device.device_id = "device_1"
 
     entity_without_area = MagicMock()
+    entity_without_area.entity_id = "sensor.unknown"
     entity_without_area.area_id = None
     entity_without_area.device_id = None
 
-    entity_map = {
-        "light.living_room": entity_with_area,
-        "switch.bedroom": entity_with_device,
-        "sensor.unknown": entity_without_area,
+    registry.entities = {
+        entry.entity_id: entry
+        for entry in (
+            entity_with_area,
+            entity_with_device,
+            entity_without_area,
+        )
     }
 
     def get_entity(entity_id: str):
-        return entity_map.get(entity_id)
+        return registry.entities.get(entity_id)
 
     registry.async_get = get_entity
     return registry
@@ -162,44 +184,3 @@ def mock_area_registry() -> MagicMock:
     return registry
 
 
-@pytest.fixture
-def sample_homekit_storage() -> dict[str, Any]:
-    """Create sample HomeKit storage data."""
-    return {
-        "version": 1,
-        "key": "homekit.test_bridge.state",
-        "data": {
-            "accessories": [
-                {
-                    "entity_id": "light.living_room",
-                    "room_name": "Default Room",
-                },
-                {
-                    "entity_id": "switch.bedroom",
-                    "room_name": "Default Room",
-                },
-                {
-                    "entity_id": "sensor.unknown",
-                    "room_name": None,
-                },
-            ]
-        },
-    }
-
-
-@pytest.fixture
-def temp_storage_dir(tmp_path: Path) -> Path:
-    """Create a temporary storage directory."""
-    storage_dir = tmp_path / ".storage"
-    storage_dir.mkdir()
-    return storage_dir
-
-
-@pytest.fixture
-def mock_storage_file(
-    temp_storage_dir: Path, sample_homekit_storage: dict[str, Any]
-) -> Path:
-    """Create a mock HomeKit storage file."""
-    storage_file = temp_storage_dir / "homekit.test_bridge.state"
-    storage_file.write_text(json.dumps(sample_homekit_storage, indent=2))
-    return storage_file

--- a/tests/ha_mocks/homeassistant/helpers/__init__.py
+++ b/tests/ha_mocks/homeassistant/helpers/__init__.py
@@ -1,5 +1,11 @@
 """Mock homeassistant.helpers package."""
 
-from . import area_registry, device_registry, entity_registry, event
+from . import area_registry, config_validation, device_registry, entity_registry, event
 
-__all__ = ["area_registry", "device_registry", "entity_registry", "event"]
+__all__ = [
+    "area_registry",
+    "config_validation",
+    "device_registry",
+    "entity_registry",
+    "event",
+]

--- a/tests/ha_mocks/homeassistant/helpers/config_validation.py
+++ b/tests/ha_mocks/homeassistant/helpers/config_validation.py
@@ -1,0 +1,16 @@
+"""Minimal mock for homeassistant.helpers.config_validation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import voluptuous as vol
+
+
+def multi_select(options: Mapping | list | set) -> vol.In:
+    """Return a simplistic multi-select validator."""
+    if isinstance(options, Mapping):
+        choices = list(options.keys())
+    else:
+        choices = list(options)
+    return vol.In(choices)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -19,6 +20,20 @@ from custom_components.homekit_room_sync.const import (
     CONF_INCLUDE_ENTITIES,
     CONF_MANAGED_BRIDGES,
 )
+
+
+@pytest.fixture(autouse=True)
+def mock_exposure_plan(monkeypatch):
+    plan = SimpleNamespace(include_entities=[], rooms_by_entity={}, allowed_entities=set())
+
+    def _fake_plan(hass, config):
+        return plan
+
+    monkeypatch.setattr(
+        "custom_components.homekit_room_sync.config_flow.build_exposure_plan",
+        _fake_plan,
+    )
+    return plan
 
 
 @pytest.fixture

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -12,6 +12,7 @@ from custom_components.homekit_room_sync.config_flow import (
     HomeKitRoomSyncOptionsFlow,
 )
 from custom_components.homekit_room_sync.const import (
+    ATTR_ENTRY_ID,
     CONF_ALLOWED_AREAS,
     CONF_BRIDGE_ID,
     CONF_BRIDGE_TITLE,
@@ -19,6 +20,8 @@ from custom_components.homekit_room_sync.const import (
     CONF_EXCLUDE_ENTITIES,
     CONF_INCLUDE_ENTITIES,
     CONF_MANAGED_BRIDGES,
+    DOMAIN,
+    SERVICE_SYNC,
 )
 
 
@@ -145,11 +148,15 @@ async def test_options_flow_updates_entry(
     flow.hass.config_entries.async_entries = MagicMock(return_value=[mock_config_entry])
     flow.hass.config_entries.async_update_entry = MagicMock()
 
+    menu = await flow.async_step_init()
+    assert menu["type"].value if hasattr(menu["type"], "value") else menu["type"] == "menu"
+
     with patch(
         "custom_components.homekit_room_sync.config_flow.async_discover_bridges",
         AsyncMock(return_value={"test_bridge": "Test Bridge"}),
     ):
-        await flow.async_step_init({CONF_MANAGED_BRIDGES: ["test_bridge"]})
+        await flow.async_step_init({"next_step_id": "configure"})
+        await flow.async_step_configure({CONF_MANAGED_BRIDGES: ["test_bridge"]})
 
     with patch(
         "custom_components.homekit_room_sync.config_flow.area_registry.async_get",
@@ -170,4 +177,34 @@ async def test_options_flow_updates_entry(
     bridge_data = updated_data[CONF_MANAGED_BRIDGES][0]
     assert bridge_data[CONF_ALLOWED_AREAS] == ["area_bedroom"]
     assert bridge_data[CONF_DEFAULT_ROOM] is None or bridge_data[CONF_DEFAULT_ROOM] == ""
+
+
+@pytest.mark.asyncio
+async def test_options_flow_resync_triggers_service(mock_config_entry: MagicMock) -> None:
+    """Options flow resync action should trigger manual sync service."""
+    flow = HomeKitRoomSyncOptionsFlow(mock_config_entry)
+    flow.hass = MagicMock()
+    flow.hass.config_entries = MagicMock()
+    flow.hass.data = {}
+    flow.hass.services = MagicMock()
+    flow.hass.services.async_call = AsyncMock()
+
+    await flow.async_step_init()
+
+    with patch(
+        "custom_components.homekit_room_sync.config_flow.build_exposure_plan",
+        return_value=SimpleNamespace(include_entities=["light.test"]),
+    ):
+        resync_form = await flow.async_step_init({"next_step_id": "resync"})
+
+    assert resync_form["type"].value if hasattr(resync_form["type"], "value") else resync_form["type"] == "form"
+
+    await flow.async_step_resync({})
+
+    flow.hass.services.async_call.assert_awaited_once_with(
+        DOMAIN,
+        SERVICE_SYNC,
+        {ATTR_ENTRY_ID: mock_config_entry.entry_id},
+        blocking=True,
+    )
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,4 +1,4 @@
-"""Tests for the HomeKit Room Sync config flow."""
+"""Tests for the HomeKit Room Sync config and options flows."""
 
 from __future__ import annotations
 
@@ -8,217 +8,151 @@ import pytest
 
 from custom_components.homekit_room_sync.config_flow import (
     HomeKitRoomSyncConfigFlow,
+    HomeKitRoomSyncOptionsFlow,
 )
 from custom_components.homekit_room_sync.const import (
     CONF_ALLOWED_AREAS,
-    CONF_BRIDGE_NAME,
+    CONF_BRIDGE_ID,
+    CONF_BRIDGE_TITLE,
     CONF_DEFAULT_ROOM,
+    CONF_EXCLUDE_ENTITIES,
+    CONF_INCLUDE_ENTITIES,
+    CONF_MANAGED_BRIDGES,
 )
 
 
-class TestHomeKitRoomSyncConfigFlow:
-    """Tests for HomeKitRoomSyncConfigFlow."""
-
-    @pytest.fixture
-    def flow(self) -> HomeKitRoomSyncConfigFlow:
-        """Create a config flow instance."""
-        flow = HomeKitRoomSyncConfigFlow()
-        flow.hass = MagicMock()
-        flow.hass.config_entries = MagicMock()
-        return flow
-
-    @pytest.mark.asyncio
-    async def test_step_user_no_bridges(self, flow: HomeKitRoomSyncConfigFlow) -> None:
-        """Test user step when no bridges are found."""
-        with patch(
-            "custom_components.homekit_room_sync.config_flow."
-            "HomeKitRoomSyncCoordinator.get_available_bridges",
-            return_value={},
-        ):
-            flow.hass.async_add_executor_job = AsyncMock(return_value={})
-            result = await flow.async_step_user()
-
-        assert result["type"] == "abort"
-        assert result["reason"] == "no_bridges"
-
-    @pytest.mark.asyncio
-    async def test_step_user_shows_form(
-        self, flow: HomeKitRoomSyncConfigFlow
-    ) -> None:
-        """Test user step shows form with available bridges."""
-        flow._async_current_entries = MagicMock(return_value=[])
-
-        async def mock_executor(func, *args):
-            return func(*args)
-
-        flow.hass.async_add_executor_job = mock_executor
-
-        with patch(
-            "custom_components.homekit_room_sync.config_flow."
-            "HomeKitRoomSyncCoordinator.get_available_bridges",
-            return_value={"bridge1": "Bridge 1", "bridge2": "Bridge 2"},
-        ):
-            result = await flow.async_step_user()
-
-        assert result["type"] == "form"
-        assert result["step_id"] == "user"
-
-    @pytest.mark.asyncio
-    async def test_step_user_all_bridges_configured(
-        self, flow: HomeKitRoomSyncConfigFlow
-    ) -> None:
-        """Test user step when all bridges are already configured."""
-        # Mock existing entry
-        existing_entry = MagicMock()
-        existing_entry.data = {CONF_BRIDGE_NAME: "bridge1"}
-        flow._async_current_entries = MagicMock(return_value=[existing_entry])
-
-        async def mock_executor(func, *args):
-            return func(*args)
-
-        flow.hass.async_add_executor_job = mock_executor
-
-        with patch(
-            "custom_components.homekit_room_sync.config_flow."
-            "HomeKitRoomSyncCoordinator.get_available_bridges",
-            return_value={"bridge1": "Bridge 1"},
-        ):
-            result = await flow.async_step_user()
-
-        assert result["type"] == "abort"
-        assert result["reason"] == "all_bridges_configured"
-
-    @pytest.mark.asyncio
-    async def test_step_user_selects_bridge(
-        self, flow: HomeKitRoomSyncConfigFlow
-    ) -> None:
-        """Test user step when selecting a bridge."""
-        flow._async_current_entries = MagicMock(return_value=[])
-
-        async def mock_executor(func, *args):
-            return func(*args)
-
-        flow.hass.async_add_executor_job = mock_executor
-
-        with patch(
-            "custom_components.homekit_room_sync.config_flow."
-            "HomeKitRoomSyncCoordinator.get_available_bridges",
-            return_value={"bridge1": "Bridge 1", "bridge2": "Bridge 2"},
-        ):
-            result = await flow.async_step_user({CONF_BRIDGE_NAME: "bridge1"})
-
-        # Should proceed to room step
-        assert result["type"] == "form"
-        assert result["step_id"] == "room"
-        assert flow._bridge_name == "bridge1"
-
-    @pytest.mark.asyncio
-    async def test_step_room_creates_entry(
-        self, flow: HomeKitRoomSyncConfigFlow, mock_area_registry: MagicMock
-    ) -> None:
-        """Test room step creates config entry."""
-        flow._bridge_name = "bridge1"
-
-        with patch(
-            "custom_components.homekit_room_sync.config_flow.area_registry.async_get",
-            return_value=mock_area_registry,
-        ):
-            result = await flow.async_step_room({CONF_DEFAULT_ROOM: "Living Room"})
-
-        assert result["type"] == "create_entry"
-        assert result["title"] == "HomeKit Bridge: bridge1"
-        assert result["data"] == {
-            CONF_BRIDGE_NAME: "bridge1",
-            CONF_DEFAULT_ROOM: "Living Room",
-            CONF_ALLOWED_AREAS: [],
-        }
-
-    @pytest.mark.asyncio
-    async def test_step_room_uses_friendly_title(
-        self, flow: HomeKitRoomSyncConfigFlow, mock_area_registry: MagicMock
-    ) -> None:
-        """Test room step uses friendly bridge name for title."""
-        flow._bridge_name = "bridge1"
-        flow._bridge_friendly_name = "Living Room Bridge"
-
-        with patch(
-            "custom_components.homekit_room_sync.config_flow.area_registry.async_get",
-            return_value=mock_area_registry,
-        ):
-            result = await flow.async_step_room({CONF_DEFAULT_ROOM: ""})
-
-        assert result["title"] == "HomeKit Bridge: Living Room Bridge"
-
-    @pytest.mark.asyncio
-    async def test_step_room_no_default_room(
-        self, flow: HomeKitRoomSyncConfigFlow, mock_area_registry: MagicMock
-    ) -> None:
-        """Test room step with no default room selected."""
-        flow._bridge_name = "bridge1"
-
-        with patch(
-            "custom_components.homekit_room_sync.config_flow.area_registry.async_get",
-            return_value=mock_area_registry,
-        ):
-            result = await flow.async_step_room({CONF_DEFAULT_ROOM: ""})
-
-        assert result["type"] == "create_entry"
-        assert result["data"][CONF_DEFAULT_ROOM] is None
-        assert result["data"][CONF_ALLOWED_AREAS] == []
+@pytest.fixture
+def flow() -> HomeKitRoomSyncConfigFlow:
+    """Create a config flow instance."""
+    flow = HomeKitRoomSyncConfigFlow()
+    flow.hass = MagicMock()
+    flow.hass.config_entries = MagicMock()
+    flow.hass.config_entries.async_entries = MagicMock(return_value=[])
+    return flow
 
 
-class TestHomeKitRoomSyncOptionsFlow:
-    """Tests for HomeKitRoomSyncOptionsFlow."""
+@pytest.mark.asyncio
+async def test_step_user_no_bridges(flow: HomeKitRoomSyncConfigFlow) -> None:
+    """Abort when no HomeKit bridges are discovered."""
+    with patch(
+        "custom_components.homekit_room_sync.config_flow.async_discover_bridges",
+        AsyncMock(return_value={}),
+    ):
+        result = await flow.async_step_user()
 
-    @pytest.mark.asyncio
-    async def test_options_flow_init(
-        self, mock_config_entry: MagicMock, mock_area_registry: MagicMock
-    ) -> None:
-        """Test options flow initialization."""
-        from custom_components.homekit_room_sync.config_flow import (
-            HomeKitRoomSyncOptionsFlow,
+    assert result["type"] == "abort"
+    assert result["reason"] == "no_bridges"
+
+
+@pytest.mark.asyncio
+async def test_step_user_all_bridges_configured(flow: HomeKitRoomSyncConfigFlow) -> None:
+    """Abort when all bridges are already configured."""
+    existing_entry = MagicMock()
+    existing_entry.data = {
+        CONF_MANAGED_BRIDGES: [{CONF_BRIDGE_ID: "bridge1"}],
+    }
+    flow._async_current_entries = MagicMock(return_value=[existing_entry])
+
+    with patch(
+        "custom_components.homekit_room_sync.config_flow.async_discover_bridges",
+        AsyncMock(return_value={"bridge1": "Bridge 1"}),
+    ):
+        result = await flow.async_step_user()
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "all_bridges_configured"
+
+
+@pytest.mark.asyncio
+async def test_step_user_to_bridge(flow: HomeKitRoomSyncConfigFlow) -> None:
+    """Selecting bridges should advance to bridge configuration."""
+    flow._async_current_entries = MagicMock(return_value=[])
+
+    with patch(
+        "custom_components.homekit_room_sync.config_flow.async_discover_bridges",
+        AsyncMock(return_value={"bridge1": "Bridge 1", "bridge2": "Bridge 2"}),
+    ):
+        result = await flow.async_step_user(
+            {CONF_MANAGED_BRIDGES: ["bridge1", "bridge2"]}
         )
 
-        flow = HomeKitRoomSyncOptionsFlow(mock_config_entry)
-        flow.hass = MagicMock()
-        flow.hass.config_entries = MagicMock()
+    assert result["type"] == "form"
+    assert result["step_id"] == "bridge"
 
-        with patch(
-            "custom_components.homekit_room_sync.config_flow.area_registry.async_get",
-            return_value=mock_area_registry,
-        ):
-            result = await flow.async_step_init()
 
-        assert result["type"] == "form"
-        assert result["step_id"] == "init"
+@pytest.mark.asyncio
+async def test_bridge_step_creates_entry(
+    flow: HomeKitRoomSyncConfigFlow,
+    mock_area_registry: MagicMock,
+) -> None:
+    """Bridge step should collect filters and create entry."""
+    flow._async_current_entries = MagicMock(return_value=[])
 
-    @pytest.mark.asyncio
-    async def test_options_flow_update(
-        self, mock_config_entry: MagicMock, mock_area_registry: MagicMock
-    ) -> None:
-        """Test options flow updating default room."""
-        from custom_components.homekit_room_sync.config_flow import (
-            HomeKitRoomSyncOptionsFlow,
+    with patch(
+        "custom_components.homekit_room_sync.config_flow.async_discover_bridges",
+        AsyncMock(return_value={"bridge1": "Bridge 1"}),
+    ):
+        await flow.async_step_user({CONF_MANAGED_BRIDGES: ["bridge1"]})
+
+    with patch(
+        "custom_components.homekit_room_sync.config_flow.area_registry.async_get",
+        return_value=mock_area_registry,
+    ):
+        result = await flow.async_step_bridge(
+            {
+                CONF_ALLOWED_AREAS: ["area_living_room"],
+                CONF_DEFAULT_ROOM: "area_bedroom",
+                CONF_INCLUDE_ENTITIES: "light.kitchen\nswitch.desk",
+                CONF_EXCLUDE_ENTITIES: "switch.desk,sensor.outdoor",
+            }
         )
 
-        flow = HomeKitRoomSyncOptionsFlow(mock_config_entry)
-        flow.hass = MagicMock()
-        flow.hass.config_entries = MagicMock()
-        flow.hass.config_entries.async_update_entry = MagicMock()
+    assert result["type"] == "create_entry"
+    data = result["data"][CONF_MANAGED_BRIDGES][0]
+    assert data[CONF_BRIDGE_ID] == "bridge1"
+    assert data[CONF_BRIDGE_TITLE] == "Bridge 1"
+    assert data[CONF_ALLOWED_AREAS] == ["area_living_room"]
+    assert data[CONF_DEFAULT_ROOM] == "Bedroom"
+    assert data[CONF_INCLUDE_ENTITIES] == ["light.kitchen", "switch.desk"]
+    # Exclude should remove duplicates present in include
+    assert data[CONF_EXCLUDE_ENTITIES] == ["sensor.outdoor"]
 
-        with patch(
-            "custom_components.homekit_room_sync.config_flow.area_registry.async_get",
-            return_value=mock_area_registry,
-        ):
-            result = await flow.async_step_init(
-                {
-                    CONF_DEFAULT_ROOM: "Bedroom",
-                    CONF_ALLOWED_AREAS: ["area_bedroom"],
-                }
-            )
 
-        assert result["type"] == "create_entry"
-        flow.hass.config_entries.async_update_entry.assert_called_once()
-        update_args = flow.hass.config_entries.async_update_entry.call_args[0][1]
-        assert update_args[CONF_ALLOWED_AREAS] == ["area_bedroom"]
+@pytest.mark.asyncio
+async def test_options_flow_updates_entry(
+    mock_config_entry: MagicMock,
+    mock_area_registry: MagicMock,
+) -> None:
+    """Options flow should persist updated bridge filters."""
+    flow = HomeKitRoomSyncOptionsFlow(mock_config_entry)
+    flow.hass = MagicMock()
+    flow.hass.config_entries = MagicMock()
+    flow.hass.config_entries.async_entries = MagicMock(return_value=[mock_config_entry])
+    flow.hass.config_entries.async_update_entry = MagicMock()
+
+    with patch(
+        "custom_components.homekit_room_sync.config_flow.async_discover_bridges",
+        AsyncMock(return_value={"test_bridge": "Test Bridge"}),
+    ):
+        await flow.async_step_init({CONF_MANAGED_BRIDGES: ["test_bridge"]})
+
+    with patch(
+        "custom_components.homekit_room_sync.config_flow.area_registry.async_get",
+        return_value=mock_area_registry,
+    ):
+        result = await flow.async_step_bridge(
+            {
+                CONF_ALLOWED_AREAS: ["area_bedroom"],
+                CONF_DEFAULT_ROOM: "",
+                CONF_INCLUDE_ENTITIES: "",
+                CONF_EXCLUDE_ENTITIES: "",
+            }
+        )
+
+    assert result["type"] == "create_entry"
+    flow.hass.config_entries.async_update_entry.assert_called_once()
+    updated_data = flow.hass.config_entries.async_update_entry.call_args[1]["data"]
+    bridge_data = updated_data[CONF_MANAGED_BRIDGES][0]
+    assert bridge_data[CONF_ALLOWED_AREAS] == ["area_bedroom"]
+    assert bridge_data[CONF_DEFAULT_ROOM] is None or bridge_data[CONF_DEFAULT_ROOM] == ""
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -217,4 +217,3 @@ async def test_area_move_triggers_update(
         "light.living_room",
         "switch.bedroom",
     }
-*** End of File

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -3,385 +3,145 @@
 from __future__ import annotations
 
 import json
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from custom_components.homekit_room_sync.bridge_manager import ManagedBridgeConfig
 from custom_components.homekit_room_sync.coordinator import (
     HomeKitRoomSyncCoordinator,
 )
+from custom_components.homekit_room_sync.storage import HomeKitStorageClient
 
 
-class TestHomeKitRoomSyncCoordinator:
-    """Tests for HomeKitRoomSyncCoordinator."""
+@pytest.fixture
+def bridge_config() -> ManagedBridgeConfig:
+    """Return a base bridge configuration."""
+    return ManagedBridgeConfig(
+        bridge_id="test_bridge",
+        friendly_name="Test Bridge",
+        allowed_areas=set(),
+        include_entities=set(),
+        exclude_entities=set(),
+        default_room="Living Room",
+    )
 
-    def test_init(self, mock_hass: MagicMock, mock_config_entry: MagicMock) -> None:
-        """Test coordinator initialization."""
-        coordinator = HomeKitRoomSyncCoordinator(mock_hass, mock_config_entry)
 
-        assert coordinator.hass == mock_hass
-        assert coordinator.entry == mock_config_entry
-        assert coordinator._bridge_name == "test_bridge"
-        assert coordinator._default_room == "Living Room"
+def _create_coordinator(
+    hass: MagicMock,
+    entry: MagicMock,
+    config: ManagedBridgeConfig,
+) -> HomeKitRoomSyncCoordinator:
+    storage = HomeKitStorageClient(hass)
+    return HomeKitRoomSyncCoordinator(hass, entry, config, storage)
 
-    def test_bridge_storage_file_path(
-        self, mock_hass: MagicMock, mock_config_entry: MagicMock
-    ) -> None:
-        """Test bridge storage file path generation."""
-        coordinator = HomeKitRoomSyncCoordinator(mock_hass, mock_config_entry)
 
-        expected_path = Path("/config/.storage/homekit.test_bridge.state")
-        assert coordinator.bridge_storage_file == expected_path
+@pytest.mark.asyncio
+async def test_sync_returns_false_when_storage_missing(
+    mock_hass: MagicMock,
+    mock_config_entry: MagicMock,
+    bridge_config: ManagedBridgeConfig,
+) -> None:
+    """Ensure sync aborts if the HomeKit storage file does not exist."""
+    mock_hass.config.path = MagicMock(return_value="/does/not/exist")
+    coordinator = _create_coordinator(mock_hass, mock_config_entry, bridge_config)
 
-    @pytest.mark.asyncio
-    async def test_async_sync_rooms_file_not_found(
-        self, mock_hass: MagicMock, mock_config_entry: MagicMock
-    ) -> None:
-        """Test sync when storage file doesn't exist."""
-        mock_hass.config.path = MagicMock(return_value="/nonexistent")
-        coordinator = HomeKitRoomSyncCoordinator(mock_hass, mock_config_entry)
+    assert await coordinator.async_sync_rooms() is False
 
+
+@pytest.mark.asyncio
+async def test_sync_updates_room_assignments(
+    mock_hass: MagicMock,
+    mock_config_entry: MagicMock,
+    mock_entity_registry: MagicMock,
+    mock_device_registry: MagicMock,
+    mock_area_registry: MagicMock,
+    temp_storage_dir: Path,
+    sample_homekit_storage: dict[str, Any],
+    bridge_config: ManagedBridgeConfig,
+) -> None:
+    """Verify that areas and default rooms are written back to storage."""
+    storage_file = temp_storage_dir / "homekit.test_bridge.state"
+    storage_file.write_text(json.dumps(sample_homekit_storage))
+    mock_hass.config.path = MagicMock(return_value=str(temp_storage_dir.parent))
+
+    coordinator = _create_coordinator(mock_hass, mock_config_entry, bridge_config)
+
+    with (
+        patch(
+            "custom_components.homekit_room_sync.coordinator.entity_registry.async_get",
+            return_value=mock_entity_registry,
+        ),
+        patch(
+            "custom_components.homekit_room_sync.coordinator.device_registry.async_get",
+            return_value=mock_device_registry,
+        ),
+        patch(
+            "custom_components.homekit_room_sync.coordinator.area_registry.async_get",
+            return_value=mock_area_registry,
+        ),
+    ):
         result = await coordinator.async_sync_rooms()
 
-        assert result is False
-
-    @pytest.mark.asyncio
-    async def test_async_sync_rooms_success(
-        self,
-        mock_hass: MagicMock,
-        mock_config_entry: MagicMock,
-        mock_entity_registry: MagicMock,
-        mock_device_registry: MagicMock,
-        mock_area_registry: MagicMock,
-        temp_storage_dir: Path,
-        sample_homekit_storage: dict[str, Any],
-    ) -> None:
-        """Test successful room sync."""
-        # Set up storage file
-        storage_file = temp_storage_dir / "homekit.test_bridge.state"
-        storage_file.write_text(json.dumps(sample_homekit_storage))
-
-        # Configure mock hass to use temp directory
-        mock_hass.config.path = MagicMock(
-            return_value=str(temp_storage_dir.parent)
-        )
-
-        coordinator = HomeKitRoomSyncCoordinator(mock_hass, mock_config_entry)
-
-        with (
-            patch(
-                "custom_components.homekit_room_sync.coordinator.entity_registry.async_get",
-                return_value=mock_entity_registry,
-            ),
-            patch(
-                "custom_components.homekit_room_sync.coordinator.device_registry.async_get",
-                return_value=mock_device_registry,
-            ),
-            patch(
-                "custom_components.homekit_room_sync.coordinator.area_registry.async_get",
-                return_value=mock_area_registry,
-            ),
-        ):
-            result = await coordinator.async_sync_rooms()
-
-        assert result is True
-
-        # Verify the storage file was updated
-        updated_data = json.loads(storage_file.read_text())
-        accessories = updated_data["data"]["accessories"]
-
-        # light.living_room should be in "Living Room" (from entity area)
-        light = next(a for a in accessories if a["entity_id"] == "light.living_room")
-        assert light["room_name"] == "Living Room"
-
-        # switch.bedroom should be in "Bedroom" (from device area)
-        switch = next(a for a in accessories if a["entity_id"] == "switch.bedroom")
-        assert switch["room_name"] == "Bedroom"
-
-        # sensor.unknown should use default room
-        sensor = next(a for a in accessories if a["entity_id"] == "sensor.unknown")
-        assert sensor["room_name"] == "Living Room"
-
-    @pytest.mark.asyncio
-    async def test_async_sync_rooms_no_changes(
-        self,
-        mock_hass: MagicMock,
-        mock_config_entry: MagicMock,
-        mock_entity_registry: MagicMock,
-        mock_device_registry: MagicMock,
-        mock_area_registry: MagicMock,
-        temp_storage_dir: Path,
-    ) -> None:
-        """Test sync when no changes are needed."""
-        # Create storage with already correct rooms
-        storage_data = {
-            "version": 1,
-            "key": "homekit.test_bridge.state",
-            "data": {
-                "accessories": [
-                    {
-                        "entity_id": "light.living_room",
-                        "room_name": "Living Room",
-                    },
-                ]
-            },
-        }
-        storage_file = temp_storage_dir / "homekit.test_bridge.state"
-        storage_file.write_text(json.dumps(storage_data))
-
-        mock_hass.config.path = MagicMock(
-            return_value=str(temp_storage_dir.parent)
-        )
-
-        coordinator = HomeKitRoomSyncCoordinator(mock_hass, mock_config_entry)
-
-        with (
-            patch(
-                "custom_components.homekit_room_sync.coordinator.entity_registry.async_get",
-                return_value=mock_entity_registry,
-            ),
-            patch(
-                "custom_components.homekit_room_sync.coordinator.device_registry.async_get",
-                return_value=mock_device_registry,
-            ),
-            patch(
-                "custom_components.homekit_room_sync.coordinator.area_registry.async_get",
-                return_value=mock_area_registry,
-            ),
-        ):
-            result = await coordinator.async_sync_rooms()
-
-        assert result is True
-        # HomeKit reload should NOT be called since no changes
-        mock_hass.services.async_call.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_async_sync_rooms_respects_allowed_areas(
-        self,
-        mock_hass: MagicMock,
-        mock_config_entry: MagicMock,
-        mock_entity_registry: MagicMock,
-        mock_device_registry: MagicMock,
-        mock_area_registry: MagicMock,
-        temp_storage_dir: Path,
-        sample_homekit_storage: dict[str, Any],
-    ) -> None:
-        """Test sync removes accessories outside allowed areas."""
-        storage_file = temp_storage_dir / "homekit.test_bridge.state"
-        storage_file.write_text(json.dumps(sample_homekit_storage))
-
-        mock_hass.config.path = MagicMock(
-            return_value=str(temp_storage_dir.parent)
-        )
-
-        mock_config_entry.data["allowed_areas"] = ["area_living_room"]
-
-        coordinator = HomeKitRoomSyncCoordinator(mock_hass, mock_config_entry)
-
-        with (
-            patch(
-                "custom_components.homekit_room_sync.coordinator.entity_registry.async_get",
-                return_value=mock_entity_registry,
-            ),
-            patch(
-                "custom_components.homekit_room_sync.coordinator.device_registry.async_get",
-                return_value=mock_device_registry,
-            ),
-            patch(
-                "custom_components.homekit_room_sync.coordinator.area_registry.async_get",
-                return_value=mock_area_registry,
-            ),
-        ):
-            result = await coordinator.async_sync_rooms()
-
-        assert result is True
-        updated_data = json.loads(storage_file.read_text())
-        accessories = updated_data["data"]["accessories"]
-
-        assert len(accessories) == 1
-        assert accessories[0]["entity_id"] == "light.living_room"
-        assert accessories[0]["room_name"] == "Living Room"
-        mock_hass.services.async_call.assert_awaited()
-
-    def test_get_room_for_entity_with_area(
-        self,
-        mock_hass: MagicMock,
-        mock_config_entry: MagicMock,
-        mock_entity_registry: MagicMock,
-        mock_device_registry: MagicMock,
-        mock_area_registry: MagicMock,
-    ) -> None:
-        """Test getting room for entity with direct area assignment."""
-        coordinator = HomeKitRoomSyncCoordinator(mock_hass, mock_config_entry)
-
-        room = coordinator._get_room_for_entity(
-            "light.living_room",
-            mock_entity_registry,
-            mock_device_registry,
-            mock_area_registry,
-        )
-
-        assert room == "Living Room"
-
-    def test_get_room_for_entity_with_device_area(
-        self,
-        mock_hass: MagicMock,
-        mock_config_entry: MagicMock,
-        mock_entity_registry: MagicMock,
-        mock_device_registry: MagicMock,
-        mock_area_registry: MagicMock,
-    ) -> None:
-        """Test getting room for entity via device area."""
-        coordinator = HomeKitRoomSyncCoordinator(mock_hass, mock_config_entry)
-
-        room = coordinator._get_room_for_entity(
-            "switch.bedroom",
-            mock_entity_registry,
-            mock_device_registry,
-            mock_area_registry,
-        )
-
-        assert room == "Bedroom"
-
-    def test_get_room_for_entity_fallback_default(
-        self,
-        mock_hass: MagicMock,
-        mock_config_entry: MagicMock,
-        mock_entity_registry: MagicMock,
-        mock_device_registry: MagicMock,
-        mock_area_registry: MagicMock,
-    ) -> None:
-        """Test getting room for entity without area falls back to default."""
-        coordinator = HomeKitRoomSyncCoordinator(mock_hass, mock_config_entry)
-
-        room = coordinator._get_room_for_entity(
-            "sensor.unknown",
-            mock_entity_registry,
-            mock_device_registry,
-            mock_area_registry,
-        )
-
-        assert room == "Living Room"  # Default room from config
-
-    def test_get_room_for_unknown_entity(
-        self,
-        mock_hass: MagicMock,
-        mock_config_entry: MagicMock,
-        mock_entity_registry: MagicMock,
-        mock_device_registry: MagicMock,
-        mock_area_registry: MagicMock,
-    ) -> None:
-        """Test getting room for entity not in registry."""
-        coordinator = HomeKitRoomSyncCoordinator(mock_hass, mock_config_entry)
-
-        room = coordinator._get_room_for_entity(
-            "light.nonexistent",
-            mock_entity_registry,
-            mock_device_registry,
-            mock_area_registry,
-        )
-
-        assert room == "Living Room"  # Falls back to default
-
-    def test_get_available_bridges(
-        self, mock_hass: MagicMock, temp_storage_dir: Path
-    ) -> None:
-        """Test discovering available HomeKit bridges with friendly names."""
-        # Create mock bridge files
-        (temp_storage_dir / "homekit.bridge1.state").write_text(
-            '{"data": {"name": "Living Room Bridge"}}'
-        )
-        (temp_storage_dir / "homekit.bridge2.state").write_text("{}")
-        (temp_storage_dir / "other_file.json").write_text("{}")
-
-        mock_hass.config.path = MagicMock(
-            return_value=str(temp_storage_dir.parent)
-        )
-
-        # Mock HomeKit config entries to provide friendly names
-        entry1 = MagicMock(entry_id="bridge1", data={"name": "Living Room Bridge"})
-        entry1.title = "Living Room Bridge"
-        entry2 = MagicMock(entry_id="bridge2", data={"name": "Bedroom Bridge"})
-        entry2.title = "Bedroom Bridge"
-        mock_hass.config_entries.async_entries = MagicMock(
-            return_value=[entry1, entry2]
-        )
-
-        bridges = HomeKitRoomSyncCoordinator.get_available_bridges(mock_hass)
-
-        assert bridges == {
-            "bridge1": "Living Room Bridge",
-            "bridge2": "Bedroom Bridge",
-        }
-
-    def test_get_available_bridges_no_storage(
-        self, mock_hass: MagicMock, tmp_path: Path
-    ) -> None:
-        """Test discovering bridges when storage dir doesn't exist."""
-        mock_hass.config.path = MagicMock(return_value=str(tmp_path / "nonexistent"))
-        mock_hass.config_entries.async_entries = MagicMock(return_value=[])
-
-        bridges = HomeKitRoomSyncCoordinator.get_available_bridges(mock_hass)
-
-        assert bridges == {}
+    assert result is True
+    updated = json.loads(storage_file.read_text())
+    accessories = updated["data"]["accessories"]
+    light = next(acc for acc in accessories if acc["entity_id"] == "light.living_room")
+    assert light["room_name"] == "Living Room"
+    switch = next(acc for acc in accessories if acc["entity_id"] == "switch.bedroom")
+    assert switch["room_name"] == "Bedroom"
+    sensor = next(acc for acc in accessories if acc["entity_id"] == "sensor.unknown")
+    assert sensor["room_name"] == "Living Room"
 
 
-class TestCoordinatorStorageOperations:
-    """Tests for coordinator storage operations."""
+@pytest.mark.asyncio
+async def test_sync_respects_area_and_override_filters(
+    mock_hass: MagicMock,
+    mock_config_entry: MagicMock,
+    mock_entity_registry: MagicMock,
+    mock_device_registry: MagicMock,
+    mock_area_registry: MagicMock,
+    temp_storage_dir: Path,
+    sample_homekit_storage: dict[str, Any],
+    bridge_config: ManagedBridgeConfig,
+) -> None:
+    """Entities outside allowed areas should be removed unless explicitly included."""
+    storage_file = temp_storage_dir / "homekit.test_bridge.state"
+    storage_file.write_text(json.dumps(sample_homekit_storage))
+    mock_hass.config.path = MagicMock(return_value=str(temp_storage_dir.parent))
 
-    @pytest.mark.asyncio
-    async def test_read_storage_file_invalid_json(
-        self, mock_hass: MagicMock, mock_config_entry: MagicMock, tmp_path: Path
-    ) -> None:
-        """Test reading invalid JSON storage file."""
-        storage_dir = tmp_path / ".storage"
-        storage_dir.mkdir()
-        storage_file = storage_dir / "homekit.test_bridge.state"
-        storage_file.write_text("invalid json {{{")
+    filtered_config = replace(
+        bridge_config,
+        allowed_areas={"area_living_room"},
+        include_entities={"sensor.unknown"},
+        exclude_entities={"switch.bedroom"},
+    )
+    coordinator = _create_coordinator(mock_hass, mock_config_entry, filtered_config)
 
-        mock_hass.config.path = MagicMock(return_value=str(tmp_path))
-        coordinator = HomeKitRoomSyncCoordinator(mock_hass, mock_config_entry)
+    with (
+        patch(
+            "custom_components.homekit_room_sync.coordinator.entity_registry.async_get",
+            return_value=mock_entity_registry,
+        ),
+        patch(
+            "custom_components.homekit_room_sync.coordinator.device_registry.async_get",
+            return_value=mock_device_registry,
+        ),
+        patch(
+            "custom_components.homekit_room_sync.coordinator.area_registry.async_get",
+            return_value=mock_area_registry,
+        ),
+    ):
+        result = await coordinator.async_sync_rooms()
 
-        result = await coordinator._read_storage_file(storage_file)
+    assert result is True
 
-        assert result is None
-
-    @pytest.mark.asyncio
-    async def test_read_storage_file_missing_data_key(
-        self, mock_hass: MagicMock, mock_config_entry: MagicMock, tmp_path: Path
-    ) -> None:
-        """Test reading storage file without 'data' key."""
-        storage_dir = tmp_path / ".storage"
-        storage_dir.mkdir()
-        storage_file = storage_dir / "homekit.test_bridge.state"
-        storage_file.write_text('{"version": 1}')
-
-        mock_hass.config.path = MagicMock(return_value=str(tmp_path))
-        coordinator = HomeKitRoomSyncCoordinator(mock_hass, mock_config_entry)
-
-        result = await coordinator._read_storage_file(storage_file)
-
-        assert result == {"data": {"version": 1}}
-
-    @pytest.mark.asyncio
-    async def test_create_backup(
-        self, mock_hass: MagicMock, mock_config_entry: MagicMock, tmp_path: Path
-    ) -> None:
-        """Test backup creation."""
-        storage_dir = tmp_path / ".storage"
-        storage_dir.mkdir()
-        storage_file = storage_dir / "homekit.test_bridge.state"
-        storage_file.write_text('{"test": "data"}')
-
-        mock_hass.config.path = MagicMock(return_value=str(tmp_path))
-        coordinator = HomeKitRoomSyncCoordinator(mock_hass, mock_config_entry)
-
-        result = await coordinator._create_backup(storage_file)
-
-        assert result is True
-        backup_file = storage_file.with_suffix(".state.backup")
-        assert backup_file.exists()
-        assert backup_file.read_text() == '{"test": "data"}'
+    updated = json.loads(storage_file.read_text())
+    entity_ids = [acc["entity_id"] for acc in updated["data"]["accessories"]]
+    assert "light.living_room" in entity_ids
+    assert "sensor.unknown" in entity_ids  # explicitly included
+    assert "switch.bedroom" not in entity_ids  # explicitly excluded
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -2,146 +2,219 @@
 
 from __future__ import annotations
 
-import json
-from dataclasses import replace
-from pathlib import Path
-from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
 from custom_components.homekit_room_sync.bridge_manager import ManagedBridgeConfig
-from custom_components.homekit_room_sync.coordinator import (
-    HomeKitRoomSyncCoordinator,
-)
-from custom_components.homekit_room_sync.storage import HomeKitStorageClient
+from custom_components.homekit_room_sync.coordinator import HomeKitRoomSyncCoordinator
 
 
-@pytest.fixture
-def bridge_config() -> ManagedBridgeConfig:
-    """Return a base bridge configuration."""
-    return ManagedBridgeConfig(
-        bridge_id="test_bridge",
-        friendly_name="Test Bridge",
-        allowed_areas=set(),
-        include_entities=set(),
-        exclude_entities=set(),
-        default_room="Living Room",
-    )
-
-
-def _create_coordinator(
-    hass: MagicMock,
-    entry: MagicMock,
-    config: ManagedBridgeConfig,
-) -> HomeKitRoomSyncCoordinator:
-    storage = HomeKitStorageClient(hass)
-    return HomeKitRoomSyncCoordinator(hass, entry, config, storage)
+def _build_config(**overrides) -> ManagedBridgeConfig:
+    base = {
+        "bridge_id": "test_bridge",
+        "friendly_name": "Test Bridge",
+        "allowed_areas": set(),
+        "include_entities": set(),
+        "exclude_entities": set(),
+        "default_room": "Living Room",
+    }
+    base.update(overrides)
+    return ManagedBridgeConfig(**base)
 
 
 @pytest.mark.asyncio
-async def test_sync_returns_false_when_storage_missing(
-    mock_hass: MagicMock,
-    mock_config_entry: MagicMock,
-    bridge_config: ManagedBridgeConfig,
+async def test_updates_filters_and_rooms(
+    mock_hass,
+    mock_config_entry,
+    mock_entity_registry,
+    mock_device_registry,
+    mock_area_registry,
+    mock_homekit_entry,
 ) -> None:
-    """Ensure sync aborts if the HomeKit storage file does not exist."""
-    mock_hass.config.path = MagicMock(return_value="/does/not/exist")
-    coordinator = _create_coordinator(mock_hass, mock_config_entry, bridge_config)
+    """Coordinator should update include_entities and entity_config."""
+    config = _build_config(allowed_areas={"area_living_room"})
+    coordinator = HomeKitRoomSyncCoordinator(mock_hass, mock_config_entry, config)
 
-    assert await coordinator.async_sync_rooms() is False
-
-
-@pytest.mark.asyncio
-async def test_sync_updates_room_assignments(
-    mock_hass: MagicMock,
-    mock_config_entry: MagicMock,
-    mock_entity_registry: MagicMock,
-    mock_device_registry: MagicMock,
-    mock_area_registry: MagicMock,
-    temp_storage_dir: Path,
-    sample_homekit_storage: dict[str, Any],
-    bridge_config: ManagedBridgeConfig,
-) -> None:
-    """Verify that areas and default rooms are written back to storage."""
-    storage_file = temp_storage_dir / "homekit.test_bridge.state"
-    storage_file.write_text(json.dumps(sample_homekit_storage))
-    mock_hass.config.path = MagicMock(return_value=str(temp_storage_dir.parent))
-
-    coordinator = _create_coordinator(mock_hass, mock_config_entry, bridge_config)
+    mock_homekit_entry.data = {"filter": {}, "entity_config": {}}
+    mock_hass.config_entries.async_reload.reset_mock()
 
     with (
         patch(
-            "custom_components.homekit_room_sync.coordinator.entity_registry.async_get",
+            "custom_components.homekit_room_sync.exposure.entity_registry.async_get",
             return_value=mock_entity_registry,
         ),
         patch(
-            "custom_components.homekit_room_sync.coordinator.device_registry.async_get",
+            "custom_components.homekit_room_sync.exposure.device_registry.async_get",
             return_value=mock_device_registry,
         ),
         patch(
-            "custom_components.homekit_room_sync.coordinator.area_registry.async_get",
+            "custom_components.homekit_room_sync.exposure.area_registry.async_get",
             return_value=mock_area_registry,
         ),
     ):
         result = await coordinator.async_sync_rooms()
 
     assert result is True
-    updated = json.loads(storage_file.read_text())
-    accessories = updated["data"]["accessories"]
-    light = next(acc for acc in accessories if acc["entity_id"] == "light.living_room")
-    assert light["room_name"] == "Living Room"
-    switch = next(acc for acc in accessories if acc["entity_id"] == "switch.bedroom")
-    assert switch["room_name"] == "Bedroom"
-    sensor = next(acc for acc in accessories if acc["entity_id"] == "sensor.unknown")
-    assert sensor["room_name"] == "Living Room"
+    data = mock_homekit_entry.data
+    assert data["filter"]["include_entities"] == ["light.living_room"]
+    assert data["filter"]["exclude_entities"] == []
+    assert data["filter"]["include_areas"] == ["area_living_room"]
+    assert data["entity_config"] == {
+        "light.living_room": {"room": "Living Room"},
+    }
+    mock_hass.config_entries.async_reload.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_sync_respects_area_and_override_filters(
-    mock_hass: MagicMock,
-    mock_config_entry: MagicMock,
-    mock_entity_registry: MagicMock,
-    mock_device_registry: MagicMock,
-    mock_area_registry: MagicMock,
-    temp_storage_dir: Path,
-    sample_homekit_storage: dict[str, Any],
-    bridge_config: ManagedBridgeConfig,
+async def test_include_and_exclude_overrides(
+    mock_hass,
+    mock_config_entry,
+    mock_entity_registry,
+    mock_device_registry,
+    mock_area_registry,
+    mock_homekit_entry,
 ) -> None:
-    """Entities outside allowed areas should be removed unless explicitly included."""
-    storage_file = temp_storage_dir / "homekit.test_bridge.state"
-    storage_file.write_text(json.dumps(sample_homekit_storage))
-    mock_hass.config.path = MagicMock(return_value=str(temp_storage_dir.parent))
-
-    filtered_config = replace(
-        bridge_config,
+    """Manual include/exclude lists should override area filters."""
+    config = _build_config(
         allowed_areas={"area_living_room"},
-        include_entities={"sensor.unknown"},
-        exclude_entities={"switch.bedroom"},
+        include_entities={"switch.bedroom"},
+        exclude_entities={"light.living_room"},
     )
-    coordinator = _create_coordinator(mock_hass, mock_config_entry, filtered_config)
+    coordinator = HomeKitRoomSyncCoordinator(mock_hass, mock_config_entry, config)
+
+    mock_homekit_entry.data = {"filter": {}, "entity_config": {}}
 
     with (
         patch(
-            "custom_components.homekit_room_sync.coordinator.entity_registry.async_get",
+            "custom_components.homekit_room_sync.exposure.entity_registry.async_get",
             return_value=mock_entity_registry,
         ),
         patch(
-            "custom_components.homekit_room_sync.coordinator.device_registry.async_get",
+            "custom_components.homekit_room_sync.exposure.device_registry.async_get",
             return_value=mock_device_registry,
         ),
         patch(
-            "custom_components.homekit_room_sync.coordinator.area_registry.async_get",
+            "custom_components.homekit_room_sync.exposure.area_registry.async_get",
             return_value=mock_area_registry,
         ),
     ):
-        result = await coordinator.async_sync_rooms()
+        await coordinator.async_sync_rooms()
 
-    assert result is True
+    data = mock_homekit_entry.data
+    assert data["filter"]["include_entities"] == ["switch.bedroom"]
+    assert data["filter"]["exclude_entities"] == ["light.living_room"]
+    assert data["entity_config"]["switch.bedroom"]["room"] == "Bedroom"
 
-    updated = json.loads(storage_file.read_text())
-    entity_ids = [acc["entity_id"] for acc in updated["data"]["accessories"]]
-    assert "light.living_room" in entity_ids
-    assert "sensor.unknown" in entity_ids  # explicitly included
-    assert "switch.bedroom" not in entity_ids  # explicitly excluded
 
+@pytest.mark.asyncio
+async def test_no_changes_skips_reload(
+    mock_hass,
+    mock_config_entry,
+    mock_entity_registry,
+    mock_device_registry,
+    mock_area_registry,
+    mock_homekit_entry,
+) -> None:
+    """Running twice without registry changes should avoid reload."""
+    config = _build_config(allowed_areas={"area_living_room"})
+    coordinator = HomeKitRoomSyncCoordinator(mock_hass, mock_config_entry, config)
+
+    mock_homekit_entry.data = {"filter": {}, "entity_config": {}}
+
+    with (
+        patch(
+            "custom_components.homekit_room_sync.exposure.entity_registry.async_get",
+            return_value=mock_entity_registry,
+        ),
+        patch(
+            "custom_components.homekit_room_sync.exposure.device_registry.async_get",
+            return_value=mock_device_registry,
+        ),
+        patch(
+            "custom_components.homekit_room_sync.exposure.area_registry.async_get",
+            return_value=mock_area_registry,
+        ),
+    ):
+        await coordinator.async_sync_rooms()
+
+    mock_hass.config_entries.async_reload.reset_mock()
+    mock_hass.config_entries.async_update_entry.reset_mock()
+
+    with (
+        patch(
+            "custom_components.homekit_room_sync.exposure.entity_registry.async_get",
+            return_value=mock_entity_registry,
+        ),
+        patch(
+            "custom_components.homekit_room_sync.exposure.device_registry.async_get",
+            return_value=mock_device_registry,
+        ),
+        patch(
+            "custom_components.homekit_room_sync.exposure.area_registry.async_get",
+            return_value=mock_area_registry,
+        ),
+    ):
+        await coordinator.async_sync_rooms()
+
+    mock_hass.config_entries.async_update_entry.assert_not_called()
+    mock_hass.config_entries.async_reload.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_area_move_triggers_update(
+    mock_hass,
+    mock_config_entry,
+    mock_entity_registry,
+    mock_device_registry,
+    mock_area_registry,
+    mock_homekit_entry,
+) -> None:
+    """Moving an entity into an allowed area should add it to the filter."""
+    config = _build_config(allowed_areas={"area_living_room"})
+    coordinator = HomeKitRoomSyncCoordinator(mock_hass, mock_config_entry, config)
+
+    mock_homekit_entry.data = {"filter": {}, "entity_config": {}}
+
+    with (
+        patch(
+            "custom_components.homekit_room_sync.exposure.entity_registry.async_get",
+            return_value=mock_entity_registry,
+        ),
+        patch(
+            "custom_components.homekit_room_sync.exposure.device_registry.async_get",
+            return_value=mock_device_registry,
+        ),
+        patch(
+            "custom_components.homekit_room_sync.exposure.area_registry.async_get",
+            return_value=mock_area_registry,
+        ),
+    ):
+        await coordinator.async_sync_rooms()
+
+    # Move the switch into the living room area
+    mock_entity_registry.entities["switch.bedroom"].area_id = "area_living_room"
+    mock_hass.config_entries.async_update_entry.reset_mock()
+
+    with (
+        patch(
+            "custom_components.homekit_room_sync.exposure.entity_registry.async_get",
+            return_value=mock_entity_registry,
+        ),
+        patch(
+            "custom_components.homekit_room_sync.exposure.device_registry.async_get",
+            return_value=mock_device_registry,
+        ),
+        patch(
+            "custom_components.homekit_room_sync.exposure.area_registry.async_get",
+            return_value=mock_area_registry,
+        ),
+    ):
+        await coordinator.async_sync_rooms()
+
+    data = mock_homekit_entry.data
+    assert set(data["filter"]["include_entities"]) == {
+        "light.living_room",
+        "switch.bedroom",
+    }
+*** End of File

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -25,11 +25,12 @@ class TestIntegrationSetup:
     ) -> None:
         """Test successful setup of config entry."""
         with patch(
-            "custom_components.homekit_room_sync.HomeKitRoomSyncCoordinator"
-        ) as mock_coordinator_class:
-            mock_coordinator = MagicMock()
-            mock_coordinator.async_sync_rooms = AsyncMock(return_value=True)
-            mock_coordinator_class.return_value = mock_coordinator
+            "custom_components.homekit_room_sync.HomeKitBridgeManager"
+        ) as mock_manager_class:
+            mock_manager = MagicMock()
+            mock_manager.async_sync = AsyncMock(return_value=True)
+            mock_manager.bridge_ids = ["test_bridge"]
+            mock_manager_class.return_value = mock_manager
 
             result = await async_setup_entry(mock_hass, mock_config_entry)
 
@@ -38,10 +39,10 @@ class TestIntegrationSetup:
         assert mock_config_entry.entry_id in mock_hass.data[DOMAIN]
 
         # Verify event listeners were registered
-        assert mock_hass.bus.async_listen.call_count == 2
+        assert mock_hass.bus.async_listen.call_count == 3
 
         # Verify initial sync was called
-        mock_coordinator.async_sync_rooms.assert_called_once()
+        mock_manager.async_sync.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_manual_sync_service_runs_coordinator(
@@ -51,11 +52,12 @@ class TestIntegrationSetup:
     ) -> None:
         """Manual sync service should trigger coordinator sync."""
         with patch(
-            "custom_components.homekit_room_sync.HomeKitRoomSyncCoordinator"
-        ) as mock_coordinator_class:
-            mock_coordinator = MagicMock()
-            mock_coordinator.async_sync_rooms = AsyncMock(return_value=True)
-            mock_coordinator_class.return_value = mock_coordinator
+            "custom_components.homekit_room_sync.HomeKitBridgeManager"
+        ) as mock_manager_class:
+            mock_manager = MagicMock()
+            mock_manager.async_sync = AsyncMock(return_value=True)
+            mock_manager.bridge_ids = ["test_bridge"]
+            mock_manager_class.return_value = mock_manager
 
             await async_setup_entry(mock_hass, mock_config_entry)
 
@@ -68,7 +70,13 @@ class TestIntegrationSetup:
         call = SimpleNamespace(data={"entry_id": mock_config_entry.entry_id})
         await service_handler(call)
 
-        mock_coordinator.async_sync_rooms.assert_awaited()
+        mock_manager.async_sync.assert_awaited()
+
+        # Call handler targeting bridge id
+        mock_manager.async_sync.reset_mock()
+        call = SimpleNamespace(data={"bridge_id": "test_bridge"})
+        await service_handler(call)
+        mock_manager.async_sync.assert_awaited()
 
     @pytest.mark.asyncio
     async def test_async_unload_entry(
@@ -79,9 +87,11 @@ class TestIntegrationSetup:
         """Test successful unload of config entry."""
         # Set up the data structure as if setup was called
         mock_unsub = MagicMock()
+        mock_manager = MagicMock()
+        mock_manager.async_shutdown = AsyncMock()
         mock_hass.data[DOMAIN] = {
             mock_config_entry.entry_id: {
-                "coordinator": MagicMock(),
+                "manager": mock_manager,
                 "listeners": [mock_unsub, mock_unsub],
                 "debounce_cancel": None,
             }
@@ -91,6 +101,7 @@ class TestIntegrationSetup:
 
         assert result is True
         assert mock_config_entry.entry_id not in mock_hass.data[DOMAIN]
+        mock_manager.async_shutdown.assert_awaited_once()
 
         # Verify listeners were removed
         assert mock_unsub.call_count == 2
@@ -103,9 +114,11 @@ class TestIntegrationSetup:
     ) -> None:
         """Test unload cancels pending sync."""
         mock_cancel = MagicMock()
+        mock_manager = MagicMock()
+        mock_manager.async_shutdown = AsyncMock()
         mock_hass.data[DOMAIN] = {
             mock_config_entry.entry_id: {
-                "coordinator": MagicMock(),
+                "manager": mock_manager,
                 "listeners": [],
                 "debounce_cancel": mock_cancel,
             }
@@ -115,6 +128,7 @@ class TestIntegrationSetup:
 
         assert result is True
         mock_cancel.assert_called_once()
+        mock_manager.async_shutdown.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_async_unload_entry_not_loaded(
@@ -142,15 +156,15 @@ class TestEventHandling:
         """Test that sync is debounced on multiple events."""
         with (
             patch(
-                "custom_components.homekit_room_sync.HomeKitRoomSyncCoordinator"
-            ) as mock_coordinator_class,
+                "custom_components.homekit_room_sync.HomeKitBridgeManager"
+            ) as mock_manager_class,
             patch(
                 "custom_components.homekit_room_sync.async_call_later"
             ) as mock_call_later,
         ):
-            mock_coordinator = MagicMock()
-            mock_coordinator.async_sync_rooms = AsyncMock(return_value=True)
-            mock_coordinator_class.return_value = mock_coordinator
+            mock_manager = MagicMock()
+            mock_manager.async_sync = AsyncMock(return_value=True)
+            mock_manager_class.return_value = mock_manager
 
             # Mock async_call_later to return a cancel function
             mock_cancel = MagicMock()
@@ -160,7 +174,7 @@ class TestEventHandling:
 
             # Get the schedule_sync callback
             calls = mock_hass.bus.async_listen.call_args_list
-            assert len(calls) == 2
+            assert len(calls) == 3
 
             # Extract the callback from the first listener
             schedule_sync = calls[0][0][1]


### PR DESCRIPTION
# Summary
- This PR introduces multi-bridge management, per-bridge area filtering, and entity include/exclude overrides for HomeKit room synchronization.
- It refactors internal storage access, enhances the configuration UI, and improves the overall stability and extensibility of the integration.
- This is needed to provide users with granular control over which HomeKit bridges and entities are managed, prevent brittle direct `.storage` file manipulation, and support more complex Home Assistant setups.

# Testing
- [x] `poetry run pytest -q`
- [x] `poetry run ruff check`
- [ ] Other (list): Manual testing of the config flow and options flow UI, including adding new integrations, updating existing ones, and verifying HomeKit room assignments.

# Deployment / Compatibility
- [ ] No breaking changes
- [x] Breaking change (describe impact and migration)
    - The `config_entry` data model has been updated from a single bridge configuration to a list of `managed_bridges`.
    - An automatic migration (`async_migrate_entry` from version 1 to 2) is implemented to seamlessly upgrade existing installations. Users should not experience data loss.

# Links
- Related issues/PRs: N/A

# Notes for Reviewers
- Please pay close attention to the new `bridge_manager.py` and `storage.py` files, which introduce core architectural changes for multi-bridge orchestration and safe `.storage` interaction.
- The `config_flow.py` has been completely rewritten to support the new multi-step, multi-bridge configuration. Manual verification of the UI experience (adding and updating the integration) is highly recommended.
- Verify the `async_migrate_entry` logic in `__init__.py` correctly transforms old config entries to the new format.
- The `coordinator.py` now receives a `ManagedBridgeConfig` and `HomeKitStorageClient` instead of directly accessing config entry data and file paths.

---
<a href="https://cursor.com/background-agent?bcId=bc-f3028235-6b35-4db9-ae92-9349ba3d3598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f3028235-6b35-4db9-ae92-9349ba3d3598"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

